### PR TITLE
feat: mockNvxDevice respects the `mode` property

### DIFF
--- a/src/NvxEpi/Factories/NvxMockDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxMockDeviceFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using NvxEpi.Devices;
+using NvxEpi.Features.Config;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 
@@ -15,6 +16,7 @@ public class NvxMockDeviceFactory : NvxBaseDeviceFactory<NvxMockDevice>
 
     public override EssentialsDevice BuildDevice(DeviceConfig dc)
     {
-        return new NvxMockDevice(dc);
+        var props = dc.Properties.ToObject<NvxMockDeviceProperties>();
+        return new NvxMockDevice(dc, props.DeviceIsTransmitter());
     }
 }

--- a/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
+++ b/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
@@ -29,6 +29,8 @@ public class NvxDeviceProperties
 public class NvxMockDeviceProperties
 {
     public int DeviceId { get; set; }
+
+    public string Mode { get; set; }
     public string StreamUrl { get; set; }
     public string MulticastVideoAddress { get; set; }
     public string MulticastAudioAddress { get; set; }
@@ -37,6 +39,12 @@ public class NvxMockDeviceProperties
 internal static class NvxDevicePropertiesExt
 {
     public static bool DeviceIsTransmitter(this NvxDeviceProperties props)
+    {
+        return !string.IsNullOrEmpty(props.Mode) &&
+                    props.Mode.Equals("tx", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool DeviceIsTransmitter(this NvxMockDeviceProperties props)
     {
         return !string.IsNullOrEmpty(props.Mode) &&
                     props.Mode.Equals("tx", StringComparison.OrdinalIgnoreCase);

--- a/src/NvxEpi/Services/InputPorts/SecondaryAudioInput.cs
+++ b/src/NvxEpi/Services/InputPorts/SecondaryAudioInput.cs
@@ -13,7 +13,7 @@ public class SecondaryAudioInput
     {
         var port = new RoutingInputPort(
             DeviceInputEnum.SecondaryAudio.Name,
-            eRoutingSignalType.Audio,
+            eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
             eRoutingPortConnectionType.Streaming,
             DeviceInputEnum.SecondaryAudio,
             device)

--- a/src/NvxEpi/Services/InputSwitching/SwitcherForSecondaryAudioOutput.cs
+++ b/src/NvxEpi/Services/InputSwitching/SwitcherForSecondaryAudioOutput.cs
@@ -62,7 +62,7 @@ public class SwitcherForSecondaryAudioOutput : IHandleInputSwitch
     {
         parent.OutputPorts.Add(new RoutingOutputPort(
             Key, 
-            eRoutingSignalType.Audio, 
+            eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
             eRoutingPortConnectionType.LineAudio,
             new SwitcherForSecondaryAudioOutput(parent), 
             parent));


### PR DESCRIPTION
In testing, it is sometimes beneficial to allow for having mock devices
that allow for checking routing behavior even without real hardware. The
Mock NVX Device will now respect the same `mode` property that the real
devices do, creating all the tielines in the central router as
appropriate.

In addition, the `SecondaryAudio` flag has been added where appropriate
to allow for the correct behavior when attempting to route Secondary
Audio in an NVX switch fabric.
