### PR TITLE
Update Essentials Dependency to 2.12.4

### DIFF
--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -10,7 +10,7 @@ namespace NvxEpi.Factories;
 
 public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T> where T : EssentialsDevice
 {
-    public const string MinumumEssentialsVersion = "2.12.3";
+    public const string MinumumEssentialsVersion = "2.12.4";
 
     static NvxBaseDeviceFactory()
     {

--- a/src/NvxEpi/NvxEpi.4Series.csproj
+++ b/src/NvxEpi/NvxEpi.4Series.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PepperDashEssentials" Version="2.12.3-current-sources.3">
+		<PackageReference Include="PepperDashEssentials" Version="2.12.3">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/src/NvxEpi/NvxEpi.4Series.csproj
+++ b/src/NvxEpi/NvxEpi.4Series.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PepperDashEssentials" Version="2.12.3">
+		<PackageReference Include="PepperDashEssentials" Version="2.12.4">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
 	</ItemGroup>


### PR DESCRIPTION
This pull request updates the minimum required version of the PepperDashEssentials library to 2.12.4. This ensures compatibility with the latest features and fixes in the Essentials platform.

Dependency version update:

* Updated the `MinumumEssentialsVersion` constant in `NvxBaseDeviceFactory` to "2.12.4" (`src/NvxEpi/Factories/NvxBaseDeviceFactory.cs`).
* Updated the `PepperDashEssentials` package reference to version 2.12.4 in the project file (`src/NvxEpi/NvxEpi.4Series.csproj`).