### PR TITLE
feat: adds inputStatus messenger to IHdmiInputMessenger

### DIFF
--- a/src/NvxEpi/McMessengers/EndpointInfoMessenger.cs
+++ b/src/NvxEpi/McMessengers/EndpointInfoMessenger.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
+﻿using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Services.Feedback;
 using PepperDash.Essentials.AppServer.Messengers;
 using PepperDash.Essentials.Core;
-using System.Linq;
 
 namespace NvxEpi.McMessengers;
 
-public class EndpointInfoMessenger:MessengerBase
-{    
+public class EndpointInfoMessenger : MessengerBase
+{
     private readonly StringFeedback deviceNameFeedback;
-    public EndpointInfoMessenger(string key, string path, NvxBaseDevice device): base(key, path, device)
+    public EndpointInfoMessenger(string key, string path, NvxBaseDevice device) : base(key, path, device)
     {
 
         deviceNameFeedback = device.Feedbacks.FirstOrDefault(fb => fb.Key == DeviceNameFeedback.Key) as StringFeedback;
@@ -29,7 +29,7 @@ public class EndpointInfoMessenger:MessengerBase
         base.RegisterActions();
 
         AddAction("/fullStatus", SendFullStatus);
-        
+        AddAction("/endpointInfo", SendFullStatus);
     }
 
     private void SendFullStatus(string id, JToken content)
@@ -37,7 +37,7 @@ public class EndpointInfoMessenger:MessengerBase
         PostStatusMessage(new EndpointInfoStateMessage
         {
             DeviceName = deviceNameFeedback?.StringValue ?? string.Empty
-        });
+        }, id);
     }
 
     private void SendUpdate(object sender, FeedbackEventArgs args)
@@ -55,7 +55,7 @@ public class EndpointInfoStateMessage : DeviceStateMessageBase
     public string DeviceName { get; set; }
 }
 
-public class EndpointInfoUpdateMessage 
+public class EndpointInfoUpdateMessage
 {
     [JsonProperty("friendlyName")]
     public string DeviceName { get; set; }

--- a/src/NvxEpi/McMessengers/IHdmiInputMessenger.cs
+++ b/src/NvxEpi/McMessengers/IHdmiInputMessenger.cs
@@ -34,9 +34,9 @@ public class IHdmiInputMessenger : MessengerBase
     {
         base.RegisterActions();
 
-        AddAction("/fullStatus", (id, content) => SendFullStatus());
+        AddAction("/fullStatus", (id, content) => SendFullStatus(id));
 
-        AddAction("/inputStatus", (id, content) => SendFullStatus());
+        AddAction("/inputStatus", (id, content) => SendFullStatus(id));
 
         foreach (var feedback in device.Feedbacks.Where((f) => f.Key.Contains("Hdmi1") || f.Key.Contains("Hdmi2")))
         {
@@ -49,7 +49,7 @@ public class IHdmiInputMessenger : MessengerBase
         }
     }
 
-    private void SendFullStatus()
+    private void SendFullStatus(string id = null)
     {
         var hdmiInputs = GetInputState();
 
@@ -62,7 +62,7 @@ public class IHdmiInputMessenger : MessengerBase
 
         try
         {
-            PostStatusMessage(message);
+            PostStatusMessage(message, id);
         }
         catch (Exception e)
         {

--- a/src/NvxEpi/McMessengers/IHdmiOutputMessenger.cs
+++ b/src/NvxEpi/McMessengers/IHdmiOutputMessenger.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Timers;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NvxEpi.Abstractions.HdmiOutput;
 using PepperDash.Core;
 using PepperDash.Essentials.AppServer.Messengers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Timers;
 
 namespace NvxEpi.McMessengers;
 
@@ -33,12 +33,14 @@ public class IHdmiOutputMessenger : MessengerBase
     {
         base.RegisterActions();
 
-        AddAction("/fullStatus",(id, content) => SendFullStatus());
+        AddAction("/fullStatus", (id, content) => SendFullStatus(id));
+        AddAction("/outputStatus", (id, content) => SendFullStatus(id));
 
         foreach (var feedback in device.Feedbacks.Where((f) => f.Key.Contains("HdmiOut")))
         {
             Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "feedback key: {key}", this, feedback.Key);
-            feedback.OutputChange += (o, a) => {
+            feedback.OutputChange += (o, a) =>
+            {
                 // Debounce the status update to avoid flooding the server with messages
                 debounceTimer.Stop();
                 debounceTimer.Start();
@@ -46,38 +48,40 @@ public class IHdmiOutputMessenger : MessengerBase
         }
     }
 
-    private void SendFullStatus()
-    {        
+    private void SendFullStatus(string id = null)
+    {
         var message = new HdmiOutputFullState
         {
             HdmiOutputs = new Dictionary<string, HdmiOutputState>
             {
                 {"HdmiOut",new  HdmiOutputState(device) }
             }
-        };            
+        };
 
         try
         {
 
-            PostStatusMessage(message);
-        } catch(Exception e)
+            PostStatusMessage(message, id);
+        }
+        catch (Exception e)
         {
             Debug.LogMessage(e, "Exception sending message {exception}", this, e);
         }
     }
 
     private void UpdateStatus()
-    {           
-        PostStatusMessage(JToken.FromObject(new {
+    {
+        PostStatusMessage(JToken.FromObject(new
+        {
             hdmiOutput = new Dictionary<string, HdmiOutputState>
             {
                 {"HdmiOut",new  HdmiOutputState(device) }
             }
         }));
-    }        
+    }
 }
 
-public class HdmiOutputFullState: DeviceStateMessageBase
+public class HdmiOutputFullState : DeviceStateMessageBase
 {
     [JsonProperty("hdmiOutputs")]
     public Dictionary<string, HdmiOutputState> HdmiOutputs { get; set; }

--- a/src/NvxEpi/McMessengers/PrimaryStreamStatusMessenger.cs
+++ b/src/NvxEpi/McMessengers/PrimaryStreamStatusMessenger.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using System.Timers;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NvxEpi.Devices;
 using PepperDash.Essentials.AppServer.Messengers;
 using PepperDash.Essentials.Core;
-using System.Timers;
 
 namespace NvxEpi.McMessengers;
 
-public class PrimaryStreamStatusMessenger:MessengerBase
+public class PrimaryStreamStatusMessenger : MessengerBase
 {
     private readonly NvxBaseDevice device;
 
@@ -30,6 +30,7 @@ public class PrimaryStreamStatusMessenger:MessengerBase
         base.RegisterActions();
 
         AddAction("/fullStatus", SendFullStatus);
+        AddAction("/videoStreamStatus", SendFullStatus);
 
         device.IsStreamingVideo.OutputChange += Debounce;
         device.VideoStreamStatus.OutputChange += Debounce;
@@ -44,8 +45,9 @@ public class PrimaryStreamStatusMessenger:MessengerBase
         debounceTimer.Start();
     }
 
-    private void SendFullStatus(string id, JToken content) {
-        PostStatusMessage(new StreamStateMessage(device));
+    private void SendFullStatus(string id, JToken content)
+    {
+        PostStatusMessage(new StreamStateMessage(device), id);
     }
 
     private void HandleUpdate(object sender, FeedbackEventArgs args)

--- a/src/NvxEpi/McMessengers/SecondaryAudioStatusMessenger.cs
+++ b/src/NvxEpi/McMessengers/SecondaryAudioStatusMessenger.cs
@@ -1,18 +1,18 @@
-﻿using Newtonsoft.Json;
+﻿using System.Timers;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NvxEpi.Devices;
 using PepperDash.Essentials.AppServer.Messengers;
 using PepperDash.Essentials.Core;
-using System.Timers;
 
 namespace NvxEpi.McMessengers;
 
-public class SecondaryAudioStatusMessenger:MessengerBase
+public class SecondaryAudioStatusMessenger : MessengerBase
 {
     private readonly NvxBaseDevice device;
 
     private readonly Timer debounceTimer;
-    public SecondaryAudioStatusMessenger(string key, string path, NvxBaseDevice device):base(key, path, device)
+    public SecondaryAudioStatusMessenger(string key, string path, NvxBaseDevice device) : base(key, path, device)
     {
         this.device = device;
 
@@ -30,6 +30,7 @@ public class SecondaryAudioStatusMessenger:MessengerBase
         base.RegisterActions();
 
         AddAction("/fullStatus", SendFullStatus);
+        AddAction("/secondaryAudioStatus", SendFullStatus);
 
         device.IsStreamingSecondaryAudio.OutputChange += Debounce;
         device.SecondaryAudioStreamStatus.OutputChange += Debounce;
@@ -44,7 +45,7 @@ public class SecondaryAudioStatusMessenger:MessengerBase
 
     private void SendFullStatus(string id, JToken content)
     {
-        PostStatusMessage(new SecondaryAudioStateMessage(device));
+        PostStatusMessage(new SecondaryAudioStateMessage(device), id);
     }
 
     private void SendUpdate(object sender, FeedbackEventArgs args)


### PR DESCRIPTION
This pull request introduces a minor update to the `IHdmiInputMessenger` class, specifically in the `RegisterActions` method. The change adds a new action endpoint to mirror an existing one.

* Added a new `/inputStatus` action that triggers the same `SendFullStatus()` method as `/fullStatus`, providing an alternative way to request the HDMI input status.