### PR TITLE
fix: change log levels for network port change

### DIFF
--- a/src/NvxEpi/Devices/NvxBaseDevice.cs
+++ b/src/NvxEpi/Devices/NvxBaseDevice.cs
@@ -102,14 +102,14 @@ public abstract class NvxBaseDevice :
 
         debounceTimer.Elapsed += (sender, args) =>
         {
-            this.LogInformation("Network change detected, updating network port information");
+            this.LogDebug("Network change detected, updating network port information");
 
             debounceTimer.Enabled = false;
             PortInformationChanged?.Invoke(this, EventArgs.Empty);
 
             foreach (var port in NetworkPorts)
             {
-                this.LogInformation("Port {portNumber} port name: {portName} portDescription: {portDescription}\r\nvlanName: {vlanName} systemName: {systemName} systemDescription: {systemDescription} managementAddress: {managementAddress}", port.DevicePortIndex, port.PortName, port.PortDescription, port.VlanName, port.SystemName, port.SystemNameDescription, port.IpManagementAddress);
+                this.LogVerbose("Port {portNumber} port name: {portName} portDescription: {portDescription}\r\nvlanName: {vlanName} systemName: {systemName} systemDescription: {systemDescription} managementAddress: {managementAddress}", port.DevicePortIndex, port.PortName, port.PortDescription, port.VlanName, port.SystemName, port.SystemNameDescription, port.IpManagementAddress);
             }
         };
     }


### PR DESCRIPTION
This pull request makes adjustments to the logging levels in the `NvxBaseDevice` class to reduce log verbosity in normal operation. Specifically, informational logs have been downgraded to debug and verbose levels.

Logging level changes:

* Changed a log message from `LogInformation` to `LogDebug` when a network change is detected, to reduce noise in the logs. (`src/NvxEpi/Devices/NvxBaseDevice.cs`)
* Changed per-port information logging from `LogInformation` to `LogVerbose`, further reducing log output during normal operation. (`src/NvxEpi/Devices/NvxBaseDevice.cs`)