### PR TITLE
fix: refactor USB routing

### DIFF
--- a/src/NvxEpi/Extensions/UsbStreamExtensions.cs
+++ b/src/NvxEpi/Extensions/UsbStreamExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NvxEpi.Abstractions.Usb;
+using PepperDash.Core;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 
@@ -10,6 +11,12 @@ public static class UsbStreamExt
 {
     public const string ClearUsbValue = "00:00:00:00:00:00";
 
+    /// <summary>
+    /// Pairs a remote USB device with a local USB device.
+    /// A local device can be linked to up to 7 remote devices, but a remote device can only have one local device.
+    /// </summary>
+    /// <param name="local">The local USB device (host)</param>
+    /// <param name="remote">The remote USB device (client)</param>
     public static void AddRemoteUsbStreamToLocal(this IUsbStreamWithHardware local, IUsbStreamWithHardware remote)
     {
         try
@@ -18,110 +25,228 @@ public static class UsbStreamExt
 
             if (local.IsRemote)
                 throw new NotSupportedException(local.Key);
+            ValidateDeviceTypes(local, remote);
+            LogPairingAttempt(local, remote);
 
-            if (!remote.IsRemote)
-                throw new NotSupportedException(remote.Key);
+            var deviceIds = GetDeviceIds(local, remote);
 
-            remote.LogDebug("Automatic Pairing is {automaticPairing}.", remote.Hardware.UsbInput.AutomaticUsbPairingEnabledFeedback.BoolValue ? "Enabled" : "Disabled");
+            var isRemoteAlreadyPairedWithLocal = IsRemoteAlreadyPairedWithLocal(remote);
 
-            // Thread.Sleep(500);
+            remote.LogDebug("Is remote already paired with a local device? {isPaired}", isRemoteAlreadyPairedWithLocal);
 
-            var remoteId = remote.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue;
-            var localId = local.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue;
-
-            var remoteRemoteIds = remote.Hardware.UsbInput.RemoteDeviceIds;
-            var localRemoteIds = local.Hardware.UsbInput.RemoteDeviceIds;
-
-            // Check if the remote id is already in the local's list of remote ids. A remote device can only have one local device, so if the remote id is already in the local's list, but not paired with it
-            // we need to find what other local device(s) are paired with that remote device and clear the remote id from those local devices.
-            if (localRemoteIds.Values.Any((x) => x.StringValue.Equals(remoteId)))
+            if (isRemoteAlreadyPairedWithLocal)
             {
-                // Get a list of all devices that are local and are currently paired with the remote device
-                var pairedLocalUsbDevices = DeviceManager.AllDevices
-                    .OfType<IUsbStreamWithHardware>()
-                    .Where(x => !x.IsRemote && x.Hardware.UsbInput.RemoteDeviceIds.Values.Any((y) => y.StringValue.Equals(remoteId))).ToList();
-
-                remote.LogVerbose("Found {hostCount} Hosts with client {remoteId} connected", pairedLocalUsbDevices.Count, remoteId);
-
-                // If we have a local device that has the same remote id as the one we're trying to add, we need to clear the remote device id from that local device
-                foreach (var localUsb in pairedLocalUsbDevices)
-                {
-                    local.LogVerbose("Clearing clients from {localId}", localUsb.UsbLocalId);
-
-                    if (localUsb.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                    {
-                        localUsb.Hardware.UsbInput.RemovePairing();
-                    }
-
-                    foreach (var usbRemoteId in localUsb.Hardware.UsbInput.RemoteDeviceIds.Values.Where(sig => sig.StringValue.Equals(remoteId)))
-                    {
-                        // Clear the remote device id if it matches the one we're trying to add
-
-                        usbRemoteId.StringValue = ClearUsbValue;
-
-                    }
-                }
-
-                // Thread.Sleep(500);
-
-                remote.LogVerbose("Remote {remoteId} already added to list. Setting remote to {localId}",
-                    remoteId, localId);
-
-                if (remote.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                    remote.Hardware.UsbInput.RemovePairing();
-
-                // Thread.Sleep(500);
-
-                // The remoteDeviceId sig is the equivalent of the RemoteDeviceIds[1]
-                remote.Hardware.UsbInput.RemoteDeviceId.StringValue = local.UsbLocalId.StringValue;
-
-                if (remote.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                    remote.Hardware.UsbInput.Pair();
-                if (local.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                    local.Hardware.UsbInput.Pair();
-
-                // Thread.Sleep(500);
-
+                HandleExistingPairing(local, remote, deviceIds);
                 return;
             }
 
-            if (local.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                local.Hardware.UsbInput.RemovePairing();
-            if (remote.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                remote.Hardware.UsbInput.RemovePairing();
-
-            // Clear all remote device ids for both local and remote devices. This removes ALL existing pairings and allows us to set the new pairing.
-            foreach (var id in local.Hardware.UsbInput.RemoteDeviceIds)
-            {
-                id.StringValue = ClearUsbValue;
-            }
-
-            foreach (var id in remote.Hardware.UsbInput.RemoteDeviceIds)
-            {
-                id.StringValue = ClearUsbValue;
-            }
-
-            // Thread.Sleep(500);
-
-            local.LogDebug("Setting Remote Id to {remoteId}", remoteId);
-
-            local.Hardware.UsbInput.RemoteDeviceId.StringValue = remote.UsbLocalId.StringValue;
-
-            remote.LogDebug("Setting Remote Id to {localId}", localId);
-
-            remote.Hardware.UsbInput.RemoteDeviceId.StringValue = local.UsbLocalId.StringValue;
-
-            // Thread.Sleep(500);
-
-            if (local.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                local.Hardware.UsbInput.Pair();
-            if (remote.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
-                remote.Hardware.UsbInput.Pair();
-            // Thread.Sleep(1000);
+            EstablishNewPairing(local, remote, deviceIds);
         }
         catch (Exception ex)
         {
             local.LogError(ex, "Error adding remote USB stream to local");
         }
+    }
+
+    /// <summary>
+    /// Validates that the devices have the correct types (local vs remote)
+    /// </summary>
+    private static void ValidateDeviceTypes(IUsbStreamWithHardware local, IUsbStreamWithHardware remote)
+    {
+        if (local.IsRemote)
+            throw new NotSupportedException($"Local device parameter is actually remote: {local.Key}");
+
+        if (!remote.IsRemote)
+            throw new NotSupportedException($"Remote device parameter is actually local: {remote.Key}");
+    }
+
+    /// <summary>
+    /// Logs the pairing attempt and current automatic pairing status
+    /// </summary>
+    private static void LogPairingAttempt(IUsbStreamWithHardware local, IUsbStreamWithHardware remote)
+    {
+        var remoteKey = remote?.Key ?? "no remote device";
+        var localKey = local?.Key ?? "no local device";
+        var remoteId = remote?.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue ?? ClearUsbValue;
+        var localId = local?.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue ?? ClearUsbValue;
+
+        local.LogDebug("Adding remote USB stream {remoteKey} with {remoteId} to local {localKey} with {localId}",
+            remoteKey, remoteId, localKey, localId);
+
+        Debug.LogDebug("remote: {remoteKey} local: {localKey}", remoteKey, localKey);
+
+        var remoteAutoPairingStatus = remote.Hardware.UsbInput.AutomaticUsbPairingEnabledFeedback.BoolValue ? "Enabled" : "Disabled";
+        var localAutoPairingStatus = local.Hardware.UsbInput.AutomaticUsbPairingEnabledFeedback.BoolValue ? "Enabled" : "Disabled";
+
+        remote.LogDebug("Automatic Pairing is {automaticPairing}", remoteAutoPairingStatus);
+        local.LogDebug("Automatic Pairing is {automaticPairing}", localAutoPairingStatus);
+    }
+
+    /// <summary>
+    /// Gets the device IDs for both local and remote devices
+    /// </summary>
+    private static (string RemoteId, string LocalId) GetDeviceIds(IUsbStreamWithHardware local, IUsbStreamWithHardware remote)
+    {
+        var remoteId = string.IsNullOrEmpty(remote.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue)
+            ? ClearUsbValue
+            : remote.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue;
+
+        var localId = string.IsNullOrEmpty(local.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue)
+            ? ClearUsbValue
+            : local.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue;
+
+        var remoteRemoteIds = remote.Hardware.UsbInput.RemoteDeviceIdFeedbacks;
+        var localRemoteIds = local.Hardware.UsbInput.RemoteDeviceIdFeedbacks;
+
+        remote.LogDebug("Remote device IDS: {@remoteIds}", remoteRemoteIds.Values.Select(x => x.StringValue));
+        local.LogDebug("Remote device IDS: {@localIds}", localRemoteIds.Values.Select(x => x.StringValue));
+
+        return (remoteId, localId);
+    }
+
+    /// <summary>
+    /// Checks if the remote device is already paired with another local device
+    /// </summary>
+    private static bool IsRemoteAlreadyPairedWithLocal(IUsbStreamWithHardware remote)
+    {
+        remote.LogDebug("Checking if remote is already paired with a local device");
+
+        return remote.Hardware.UsbInput.RemoteDeviceIdFeedbacks.Values
+            .Any(x =>
+            {
+                remote.LogDebug("Checking remote ID {remoteId} against local ID {localId}", x.StringValue, ClearUsbValue);
+                return !x.StringValue.Equals(ClearUsbValue);
+            });
+    }
+
+
+    /// <summary>
+    /// Handles the case where the remote device is already paired with some local device
+    /// </summary>
+    private static void HandleExistingPairing(IUsbStreamWithHardware local, IUsbStreamWithHardware remote,
+        (string RemoteId, string LocalId) deviceIds)
+    {
+        ClearExistingPairingsForRemote(remote, deviceIds.RemoteId);
+        SetupDirectPairing(local, remote, deviceIds);
+    }
+
+    /// <summary>
+    /// Clears existing pairings for the remote device from all local devices
+    /// </summary>
+    private static void ClearExistingPairingsForRemote(IUsbStreamWithHardware remote, string remoteId)
+    {
+        remote.LogDebug("Clearing existing pairings for remote ID {remoteId}", remoteId);
+
+        var pairedLocalDevices = DeviceManager.AllDevices
+            .OfType<IUsbStreamWithHardware>()
+            .Where(x => !x.IsRemote &&
+                       x.Hardware.UsbInput.RemoteDeviceIdFeedbacks.Values.Any(y => y.StringValue.Equals(remoteId)))
+            .ToList();
+
+        remote.LogVerbose("Found {hostCount} Hosts with client {remoteId} connected", pairedLocalDevices.Count, remoteId);
+
+        foreach (var localDevice in pairedLocalDevices)
+        {
+            remote.LogVerbose("Clearing clients from {localId}", localDevice.UsbLocalId);
+
+            RemovePairingIfManual(localDevice);
+            ClearMatchingRemoteIds(localDevice, remoteId);
+        }
+    }
+
+    /// <summary>
+    /// Sets up direct pairing between local and remote devices
+    /// </summary>
+    private static void SetupDirectPairing(IUsbStreamWithHardware local, IUsbStreamWithHardware remote,
+        (string RemoteId, string LocalId) deviceIds)
+    {
+        remote.LogVerbose("Remote {remoteId} already added to list. Setting remote to {localId}",
+            deviceIds.RemoteId, deviceIds.LocalId);
+
+        RemovePairingIfManual(remote);
+
+        // Set the remote device to point to the local device
+        remote.Hardware.UsbInput.RemoteDeviceId.StringValue = local.UsbLocalId.StringValue;
+
+        EstablishPairingIfManual(remote);
+        EstablishPairingIfManual(local);
+    }
+
+    /// <summary>
+    /// Establishes a new pairing between local and remote devices
+    /// </summary>
+    private static void EstablishNewPairing(IUsbStreamWithHardware local, IUsbStreamWithHardware remote,
+        (string RemoteId, string LocalId) deviceIds)
+    {
+        RemovePairingIfManual(local);
+        RemovePairingIfManual(remote);
+
+        ClearAllRemoteDeviceIds(local);
+        ClearAllRemoteDeviceIds(remote);
+
+        SetupBidirectionalPairing(local, remote, deviceIds);
+
+        EstablishPairingIfManual(local);
+        EstablishPairingIfManual(remote);
+    }
+
+    /// <summary>
+    /// Removes pairing if automatic pairing is disabled (manual mode)
+    /// </summary>
+    private static void RemovePairingIfManual(IUsbStreamWithHardware device)
+    {
+        if (device.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
+        {
+            device.Hardware.UsbInput.RemovePairing();
+        }
+    }
+
+    /// <summary>
+    /// Establishes pairing if automatic pairing is disabled (manual mode)
+    /// </summary>
+    private static void EstablishPairingIfManual(IUsbStreamWithHardware device)
+    {
+        if (device.Hardware.UsbInput.AutomaticUsbPairingDisabledFeedback.BoolValue)
+        {
+            device.Hardware.UsbInput.Pair();
+        }
+    }
+
+    /// <summary>
+    /// Clears remote device IDs that match the specified remote ID
+    /// </summary>
+    private static void ClearMatchingRemoteIds(IUsbStreamWithHardware localDevice, string remoteId)
+    {
+        var matchingIds = localDevice.Hardware.UsbInput.RemoteDeviceIds.Values
+            .Where(sig => sig.StringValue.Equals(remoteId));
+
+        foreach (var usbRemoteId in matchingIds)
+        {
+            usbRemoteId.StringValue = ClearUsbValue;
+        }
+    }
+
+    /// <summary>
+    /// Clears all remote device IDs for the specified device
+    /// </summary>
+    private static void ClearAllRemoteDeviceIds(IUsbStreamWithHardware device)
+    {
+        foreach (var id in device.Hardware.UsbInput.RemoteDeviceIds)
+        {
+            id.StringValue = ClearUsbValue;
+        }
+    }
+
+    /// <summary>
+    /// Sets up bidirectional pairing between local and remote devices
+    /// </summary>
+    private static void SetupBidirectionalPairing(IUsbStreamWithHardware local, IUsbStreamWithHardware remote,
+        (string RemoteId, string LocalId) deviceIds)
+    {
+        local.LogDebug("Setting Remote Id to {remoteId}", deviceIds.RemoteId);
+        local.Hardware.UsbInput.RemoteDeviceIds[1].StringValue = remote.UsbLocalId.StringValue;
+
+        remote.LogDebug("Setting Remote Id to {localId}", deviceIds.LocalId);
+        remote.Hardware.UsbInput.RemoteDeviceIds[1].StringValue = local.UsbLocalId.StringValue;
     }
 }

--- a/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
+++ b/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
@@ -31,6 +31,8 @@ public class NvxMockDeviceProperties : BaseStreamingDeviceProperties
     public int DeviceId { get; set; }
 
     public string Mode { get; set; }
+
+    public NvxUsbProperties Usb { get; set; }
 }
 
 internal static class NvxDevicePropertiesExt

--- a/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
+++ b/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
@@ -11,6 +11,7 @@ using NvxEpi.Extensions;
 using NvxEpi.Services.InputSwitching;
 using NvxEpi.Services.Utilities;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 
 namespace NvxEpi.Features.Routing;
@@ -27,7 +28,7 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
 
     private void AddFeedbackMatchObjects()
     {
-        Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "Updating feedback match objects", this);
+        this.LogVerbose("Updating feedback match objects");
 
         foreach (var input in InputPorts.Where(ip => ip.Selector is IStreamWithHardware))
         {
@@ -36,15 +37,15 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
                 continue;
             }
 
-            Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "Updating match object for {key}", this, input.Key);
+            this.LogVerbose("Updating match object for {key}", this, input.Key);
 
             tx.Hardware.BaseEvent += (o, a) =>
             {
                 if (a.EventId != DMInputEventIds.ServerUrlEventId) return;
 
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "Updating Feedback match object for {input}", this, input.Key);
+                this.LogVerbose("Updating Feedback match object for {input}", this, input.Key);
 
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "Updating Feedback match object for {input} to {url}", this, input.Key, tx.Hardware.Control.ServerUrlFeedback.StringValue);
+                this.LogVerbose("Updating Feedback match object for {input} to {url}", this, input.Key, tx.Hardware.Control.ServerUrlFeedback.StringValue);
 
                 input.FeedbackMatchObject = tx.Hardware.Control.ServerUrlFeedback.StringValue;
             };


### PR DESCRIPTION
This pull request introduces significant improvements to USB device pairing logic and routing feedback in the NVX EPI codebase. The most important changes include a major refactor of the `AddRemoteUsbStreamToLocal` method, enhanced logging for routing and pairing events, and improved handling of current USB routes. These updates aim to make the code more modular, maintainable, and easier to debug.

**USB Pairing Logic Refactor:**
- The `AddRemoteUsbStreamToLocal` method in `UsbStreamExtensions.cs` has been extensively refactored for clarity and maintainability. The logic for pairing, unpairing, and validating devices is now separated into smaller, well-documented helper methods. This makes the pairing process more robust and easier to follow. [[1]](diffhunk://#diff-145df9111ea0dad9428dcb9844a9acde47f5f32d09837ff41a1ebf37da253548R14-R19) [[2]](diffhunk://#diff-145df9111ea0dad9428dcb9844a9acde47f5f32d09837ff41a1ebf37da253548R28-R251)

**Logging Improvements:**
- Replaced generic `Debug.LogMessage` calls with more context-aware logging using `this.LogVerbose`, `this.LogDebug`, and `this.LogError` throughout `PrimaryStreamRouter.cs` and `UsbRouter.cs`. This provides clearer and more consistent logs for routing and pairing operations. [[1]](diffhunk://#diff-f6091b2a1a2d74ad692326da6af6aa5d32c3c4b75dae50ad6dca93c00b1e46aeR14) [[2]](diffhunk://#diff-f6091b2a1a2d74ad692326da6af6aa5d32c3c4b75dae50ad6dca93c00b1e46aeL30-R31) [[3]](diffhunk://#diff-f6091b2a1a2d74ad692326da6af6aa5d32c3c4b75dae50ad6dca93c00b1e46aeL39-R48) [[4]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeR80-R107) [[5]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeR129-R130) [[6]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeL158-R209)

**USB Routing Enhancements:**
- Improved the `UpdateCurrentRoutes` method in `UsbRouter.cs` to better handle edge cases, such as when local or remote devices are null. The method now logs detailed information about route updates and clears routes more reliably. [[1]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeR80-R107) [[2]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeR129-R130)
- Added a new helper method, `GetRouteDescriptorByInputPort`, to efficiently find and remove routes by input port.

**Configuration and Initialization:**
- Added support for `NvxUsbProperties` in `NvxMockDeviceProperties` to allow for more complete device configuration.
- Adjusted the order of post-activation actions in `UsbRouter` to ensure routing ports are added before feedback match objects, improving initialization reliability.

**Dependency and Usability Updates:**
- Added missing `using` directives in several files to support new logging and device management functionality. [[1]](diffhunk://#diff-145df9111ea0dad9428dcb9844a9acde47f5f32d09837ff41a1ebf37da253548R4) [[2]](diffhunk://#diff-b642ed20d3e871b6c42651b8dc8a0be0d1ade6269fb0848c34a22aa6449c8bfeR3)

These changes collectively improve the reliability, maintainability, and debuggability of USB device routing and pairing in the system.