### PR TITLE
fix: remove unused InUseTracker timer logic from PrimaryStreamRouter …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,7 +363,8 @@ MigrationBackup/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -383,3 +384,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+.DS_Store

--- a/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
+++ b/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
@@ -264,32 +264,6 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
                 }
             });
 
-        foreach (var routingOutputPort in OutputPorts)
-        {
-            var port = routingOutputPort;
-            const int delayTime = 250;
-
-            var timer = new CTimer(
-                o =>
-                {
-                    if (port.InUseTracker.InUseFeedback.BoolValue)
-                        return;
-
-                    this.LogInformation("Port not in use: {portKey}, clearing stream", port.Key);
-                    ExecuteSwitch(null, port.Selector, eRoutingSignalType.AudioVideo);
-                },
-                Timeout.Infinite
-            );
-
-            port.InUseTracker.InUseFeedback.OutputChange += (sender, args) =>
-            {
-                if (args.BoolValue)
-                    return;
-
-                timer.Reset(delayTime);
-            };
-        }
-
         return base.CustomActivate();
     }
 
@@ -298,126 +272,126 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
         switch (args.EventId)
         {
             case DMInputEventIds.ServerUrlEventId:
-            {
-                if (device == null)
                 {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Information,
-                        "Device is null",
-                        this
-                    );
+                    if (device == null)
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Information,
+                            "Device is null",
+                            this
+                        );
 
-                    return;
-                }
+                        return;
+                    }
 
-                var currentUrl = device.Hardware.Control.ServerUrlFeedback.StringValue;
-
-                Debug.LogMessage(
-                    Serilog.Events.LogEventLevel.Verbose,
-                    "Received Server URL event {deviceKey};{eventId}:{serverUrl}",
-                    this,
-                    device?.Key,
-                    args.EventId,
-                    currentUrl
-                );
-
-                var existingRoute = CurrentRoutes.FirstOrDefault(
-                    (cr) => (cr.OutputPort.Selector as IKeyed)?.Key == device.Key
-                );
-
-                if (string.IsNullOrEmpty(currentUrl) && existingRoute != null)
-                {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Verbose,
-                        "Removing route {currentRoute}",
-                        this,
-                        existingRoute
-                    );
-
-                    CurrentRoutes.Remove(existingRoute);
-
-                    RouteChanged?.Invoke(this, null);
-                    break;
-                }
-
-                var inputPort = InputPorts.FirstOrDefault(ip =>
-                {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Debug,
-                        "Checking {currentUrl} against {feedbackMatchObject}",
-                        this,
-                        currentUrl,
-                        ip.FeedbackMatchObject
-                    );
-                    return ip.FeedbackMatchObject != null
-                        && ip.FeedbackMatchObject.Equals(currentUrl);
-                });
-
-                if (inputPort == null && existingRoute != null)
-                {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Information,
-                        "No input port found for URL {currentUrl}",
-                        this,
-                        currentUrl
-                    );
+                    var currentUrl = device.Hardware.Control.ServerUrlFeedback.StringValue;
 
                     Debug.LogMessage(
                         Serilog.Events.LogEventLevel.Verbose,
-                        "Removing route {currentRoute}",
+                        "Received Server URL event {deviceKey};{eventId}:{serverUrl}",
                         this,
-                        existingRoute
-                    );
-
-                    CurrentRoutes.Remove(existingRoute);
-
-                    RouteChanged?.Invoke(this, null);
-
-                    break;
-                }
-
-                if (existingRoute != null)
-                {
-                    existingRoute.InputPort = inputPort;
-
-                    RouteChanged?.Invoke(this, existingRoute);
-                    return;
-                }
-
-                if (inputPort == null)
-                {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Information,
-                        "No input port found for URL {currentUrl}",
-                        this,
+                        device?.Key,
+                        args.EventId,
                         currentUrl
                     );
-                    return;
-                }
 
-                var outputPort = OutputPorts.FirstOrDefault(op =>
-                    (op.Selector as IKeyed)?.Key == device.Key
-                );
-
-                if (outputPort == null)
-                {
-                    Debug.LogMessage(
-                        Serilog.Events.LogEventLevel.Information,
-                        "No output port found for {deviceKey}",
-                        this,
-                        device.Key
+                    var existingRoute = CurrentRoutes.FirstOrDefault(
+                        (cr) => (cr.OutputPort.Selector as IKeyed)?.Key == device.Key
                     );
+
+                    if (string.IsNullOrEmpty(currentUrl) && existingRoute != null)
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Verbose,
+                            "Removing route {currentRoute}",
+                            this,
+                            existingRoute
+                        );
+
+                        CurrentRoutes.Remove(existingRoute);
+
+                        RouteChanged?.Invoke(this, null);
+                        break;
+                    }
+
+                    var inputPort = InputPorts.FirstOrDefault(ip =>
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Debug,
+                            "Checking {currentUrl} against {feedbackMatchObject}",
+                            this,
+                            currentUrl,
+                            ip.FeedbackMatchObject
+                        );
+                        return ip.FeedbackMatchObject != null
+                            && ip.FeedbackMatchObject.Equals(currentUrl);
+                    });
+
+                    if (inputPort == null && existingRoute != null)
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Information,
+                            "No input port found for URL {currentUrl}",
+                            this,
+                            currentUrl
+                        );
+
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Verbose,
+                            "Removing route {currentRoute}",
+                            this,
+                            existingRoute
+                        );
+
+                        CurrentRoutes.Remove(existingRoute);
+
+                        RouteChanged?.Invoke(this, null);
+
+                        break;
+                    }
+
+                    if (existingRoute != null)
+                    {
+                        existingRoute.InputPort = inputPort;
+
+                        RouteChanged?.Invoke(this, existingRoute);
+                        return;
+                    }
+
+                    if (inputPort == null)
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Information,
+                            "No input port found for URL {currentUrl}",
+                            this,
+                            currentUrl
+                        );
+                        return;
+                    }
+
+                    var outputPort = OutputPorts.FirstOrDefault(op =>
+                        (op.Selector as IKeyed)?.Key == device.Key
+                    );
+
+                    if (outputPort == null)
+                    {
+                        Debug.LogMessage(
+                            Serilog.Events.LogEventLevel.Information,
+                            "No output port found for {deviceKey}",
+                            this,
+                            device.Key
+                        );
+                        break;
+                    }
+
+                    var route = new RouteSwitchDescriptor(outputPort, inputPort);
+
+                    CurrentRoutes.Add(route);
+
+                    RouteChanged?.Invoke(this, route);
+
                     break;
                 }
-
-                var route = new RouteSwitchDescriptor(outputPort, inputPort);
-
-                CurrentRoutes.Add(route);
-
-                RouteChanged?.Invoke(this, route);
-
-                break;
-            }
         }
     }
 

--- a/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
+++ b/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
@@ -106,31 +106,6 @@ public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
                 OutputPorts.Add(output);
             });
 
-        foreach (var routingOutputPort in OutputPorts)
-        {
-            var port = routingOutputPort;
-            const int delayTime = 250;
-
-            var timer = new CTimer(
-                o =>
-                {
-                    if (port.InUseTracker.InUseFeedback.BoolValue)
-                        return;
-
-                    ExecuteSwitch(null, port.Selector, eRoutingSignalType.Audio);
-                },
-                Timeout.Infinite
-            );
-
-            port.InUseTracker.InUseFeedback.OutputChange += (sender, args) =>
-            {
-                if (args.BoolValue)
-                    return;
-
-                timer.Reset(delayTime);
-            };
-        }
-
         return base.CustomActivate();
     }
 
@@ -139,65 +114,65 @@ public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
         switch (args.EventId)
         {
             case DMInputEventIds.DmNaxAudioSourceFeedbackEventId:
-            {
-                var currentUrl = device
-                    .Hardware
-                    .DmNaxRouting
-                    .DmNaxReceive
-                    .MulticastAddressFeedback
-                    .StringValue;
-
-                this.LogVerbose(
-                    "Received server URL event {eventId}:{serverUrl}",
-                    args.EventId,
-                    currentUrl
-                );
-
-                if (string.IsNullOrEmpty(currentUrl))
                 {
-                    var index = CurrentRoutes.FindIndex(
-                        (r) => r.OutputPort.ParentDevice.Key == device.Key
+                    var currentUrl = device
+                        .Hardware
+                        .DmNaxRouting
+                        .DmNaxReceive
+                        .MulticastAddressFeedback
+                        .StringValue;
+
+                    this.LogVerbose(
+                        "Received server URL event {eventId}:{serverUrl}",
+                        args.EventId,
+                        currentUrl
                     );
 
-                    if (index < 0)
+                    if (string.IsNullOrEmpty(currentUrl))
                     {
-                        return;
+                        var index = CurrentRoutes.FindIndex(
+                            (r) => r.OutputPort.ParentDevice.Key == device.Key
+                        );
+
+                        if (index < 0)
+                        {
+                            return;
+                        }
+
+                        CurrentRoutes.RemoveAt(index);
+
+                        RouteChanged?.Invoke(this, null);
+                        break;
                     }
 
-                    CurrentRoutes.RemoveAt(index);
+                    var inputPort = InputPorts.FirstOrDefault(ip =>
+                        ip.FeedbackMatchObject.Equals(currentUrl)
+                    );
 
-                    RouteChanged?.Invoke(this, null);
+                    if (inputPort == null)
+                    {
+                        this.LogInformation("No input port found for URL {currentUrl}", currentUrl);
+                        break;
+                    }
+
+                    var outputPort = OutputPorts.FirstOrDefault(op =>
+                        op.ParentDevice.Key == device.Key
+                    );
+
+                    if (outputPort == null)
+                    {
+                        this.LogInformation("No output port found for {deviceKey}", device.Key);
+                        break;
+                    }
+
+                    var route = new RouteSwitchDescriptor(outputPort, inputPort);
+
+                    CurrentRoutes.Add(route);
+
+                    RouteChanged?.Invoke(this, route);
+
                     break;
                 }
-
-                var inputPort = InputPorts.FirstOrDefault(ip =>
-                    ip.FeedbackMatchObject.Equals(currentUrl)
-                );
-
-                if (inputPort == null)
-                {
-                    this.LogInformation("No input port found for URL {currentUrl}", currentUrl);
-                    break;
-                }
-
-                var outputPort = OutputPorts.FirstOrDefault(op =>
-                    op.ParentDevice.Key == device.Key
-                );
-
-                if (outputPort == null)
-                {
-                    this.LogInformation("No output port found for {deviceKey}", device.Key);
-                    break;
-                }
-
-                var route = new RouteSwitchDescriptor(outputPort, inputPort);
-
-                CurrentRoutes.Add(route);
-
-                RouteChanged?.Invoke(this, route);
-
-                break;
-            }
         }
     }
 


### PR DESCRIPTION
This pull request removes the logic that automatically clears streams from output ports when they are no longer in use in both the primary and secondary audio routing features. The affected code previously set up timers to clear streams after a delay when an output port was not in use.  It was also causing undesired behaviour by clearing routes when the port was still in use.

Key changes:

**Removal of automatic stream clearing logic:**

* [`PrimaryStreamRouter.cs`](diffhunk://#diff-f6091b2a1a2d74ad692326da6af6aa5d32c3c4b75dae50ad6dca93c00b1e46aeL267-L292): Removed the code that set up timers to clear audio/video streams from output ports when their `InUseFeedback` indicated they were not in use.
* [`SecondaryAudioRouter.cs`](diffhunk://#diff-cd62062698eb55cb84d107501191bacce4b9f87eaeed6f79327ba96fd0d84d1bL109-L133): Removed similar logic for clearing audio streams from output ports when not in use.…and SecondaryAudioRouter