### PR TITLE
Enhance error logging for USB support in UsbRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ noSwitch
 
 ```json
 {
-    "key": "NvxRouter",
+    "key": "nvx-router",
     "name": "NvxRouter",
     "type": "dynNvx",
     "group": "nvx",

--- a/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Features.Config;
+using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 
@@ -28,9 +30,23 @@ public class Nvx36XDeviceFactory : NvxBaseDeviceFactory<Nvx36X>
         TypeNames = _typeNames.ToList();
     }
 
+    private static readonly string[] _usbUnsupportedTypes = { "dmnvxe760", "dmnvxe760c" };
+
+    private static void WarnIfUsbConfiguredOnUnsupportedDevice(DeviceConfig dc, NvxDeviceProperties props)
+    {
+        if (props.Usb == null)
+            return;
+
+        var isUnsupported = Array.Exists(_usbUnsupportedTypes, t => t.Equals(dc.Type, StringComparison.OrdinalIgnoreCase));
+
+        if (isUnsupported)
+            Debug.LogError("Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
+    }
+
     public override EssentialsDevice BuildDevice(DeviceConfig dc)
     {
         var props = NvxDeviceProperties.FromDeviceConfig(dc);
+        WarnIfUsbConfiguredOnUnsupportedDevice(dc, props);
         var deviceBuild = GetDeviceBuildAction(dc.Type, props);
         return new Nvx36X(dc, deviceBuild, props.DeviceIsTransmitter());
     }

--- a/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
@@ -6,6 +6,7 @@ using NvxEpi.Features.Config;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
+using Serilog.Events;
 
 namespace NvxEpi.Factories;
 
@@ -40,7 +41,7 @@ public class Nvx36XDeviceFactory : NvxBaseDeviceFactory<Nvx36X>
         var isUnsupported = Array.Exists(_usbUnsupportedTypes, t => t.Equals(dc.Type, StringComparison.OrdinalIgnoreCase));
 
         if (isUnsupported)
-            Debug.LogError("Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
+            Debug.LogMessage(LogEventLevel.Warning, "Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
     }
 
     public override EssentialsDevice BuildDevice(DeviceConfig dc)

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -240,6 +240,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
                 continue;
             }
 
+            if (device.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping feedback subscription", device.Key);
+                continue;
+            }
+
             // getting current local device for this remote when it changes and setting the feedback match object for this input port to that value
 
             device.Hardware.UsbInput.UsbInputChange += (o, a) =>
@@ -298,6 +304,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Output Port: {portKey}", outputPort.Key);
             OutputPorts.Add(outputPort);
+
+            if (remoteDevice.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", remoteDevice.Key);
+                continue;
+            }
 
             remoteDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {
@@ -368,6 +380,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Input Port: {portKey}", inputPort.Key);
             InputPorts.Add(inputPort);
+
+            if (localDevice.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", localDevice.Key);
+                continue;
+            }
 
             localDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -242,7 +242,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (device.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping feedback subscription", device.Key);
                 continue;
             }
 
@@ -307,7 +306,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (remoteDevice.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", remoteDevice.Key);
                 continue;
             }
 
@@ -383,7 +381,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (localDevice.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", localDevice.Key);
                 continue;
             }
 

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -240,11 +240,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
                 continue;
             }
 
-            if (device.Hardware.UsbInput == null)
-            {
-                continue;
-            }
-
             // getting current local device for this remote when it changes and setting the feedback match object for this input port to that value
 
             device.Hardware.UsbInput.UsbInputChange += (o, a) =>
@@ -281,12 +276,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         // Remote devices in NVX world are the USB peripherals like keyboards or touchscreen
         var usbRemoteDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => usb.IsRemote);
+            .Where(usb => usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // Local devices in NVX world are the USB Hosts like a PC
         var usbLocalDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => !usb.IsRemote);
+            .Where(usb => !usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // A local device can have multiple remote devices, but a remote device can only have one local device.
         // remote devices will be treated as Outputs and local devices as Inputs to mimic traditional video routing behavior.
@@ -303,11 +298,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Output Port: {portKey}", outputPort.Key);
             OutputPorts.Add(outputPort);
-
-            if (remoteDevice.Hardware.UsbInput == null)
-            {
-                continue;
-            }
 
             remoteDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {
@@ -378,11 +368,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Input Port: {portKey}", inputPort.Key);
             InputPorts.Add(inputPort);
-
-            if (localDevice.Hardware.UsbInput == null)
-            {
-                continue;
-            }
 
             localDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {


### PR DESCRIPTION
fix: handle E760 devices without USB hardware support

Problem:

The DM NVX E760 and E760C are video/audio-only encoders that do not have USB hardware (UsbInput is always null). When these devices were configured with a usb block in their config, the UsbRouter would crash during post-activation with a NullReferenceException when attempting to subscribe to Hardware.UsbInput.UsbInputChange.

Changes:

Nvx36XDeviceFactory — Early warning at build time
Added WarnIfUsbConfiguredOnUnsupportedDevice() which logs a clear error during device build if a usb block is present in the config for an E760/E760C device. This surfaces the misconfiguration immediately rather than allowing it to manifest as a cryptic null reference later.

Example: `[2026-03-26 16:47:52.525][WARN][App 1] Device 'TxWPRear' of type 'dmnvxe760c' does not support USB, but USB is configured in config. USB configuration will be ignored.

UsbRouter — Null guard for devices without USB hardware
Added UsbInput == null checks in AddRoutingPorts() and AddFeedbackMatchObjects() before subscribing to UsbInputChange events. Devices without USB hardware are now silently skipped, preventing the NullReferenceException on startup.

README.md — Fix conflicting key in config example
Changed the dynNvx example device key from "NvxRouter" to "nvx-router". The key "NvxRouter" is reserved internally by the NvxGlobalRouter singleton and would cause a DeviceManager key collision if used in config.

Root Cause:

The E760/E760C were previously built by Nvx36XDeviceFactory → Nvx36X, which always called UsbStream.GetUsbStream() and registered the device as IUsbStreamWithHardware. UsbRouter then picked it up and attempted to wire USB events against a null UsbInput. The UsbStream constructor already guarded against this internally, but UsbRouter did not.