### PR TITLE
fix: Improve USB stream pairing reliability and feedback

### DIFF
--- a/src/NvxEpi/Extensions/UsbStreamExtensions.cs
+++ b/src/NvxEpi/Extensions/UsbStreamExtensions.cs
@@ -35,6 +35,11 @@ public static class UsbStreamExt
             ValidateDeviceTypes(local, remote);
 
             var localId = remote.Hardware.UsbInput.LocalDeviceIdFeedback.StringValue;
+            if (string.IsNullOrEmpty(localId) )
+            {
+                remote.LogDebug("Remote device {remoteKey} has no local ID, skipping", remote.Key);
+                return;
+            }
 
             remote.LogDebug(
                 "Attempting to pair remote device {remoteKey} with local device {localKey} (local ID: {localId})",
@@ -46,10 +51,11 @@ public static class UsbStreamExt
             if (local.Hardware.UsbInput.MultipleUsbDeviceEnabledFeedback.BoolValue)
             {
                 var remoteIds = local
-                    .Hardware.UsbInput.RemoteDeviceIds.Values.Select(x => x.StringValue)
+                    .Hardware.UsbInput.RemoteDeviceIdFeedbacks.Values.Select(x => x.StringValue)
                     .ToList();
 
-                if (remoteIds.Contains(localId))
+                var pairedIndex = remoteIds.FindIndex(x => x.Equals(localId, StringComparison.OrdinalIgnoreCase));
+                if (pairedIndex >= 0)
                 {
                     local.LogDebug(
                         "Local device {remoteKey} already has local ID {localId}",
@@ -59,7 +65,7 @@ public static class UsbStreamExt
                 }
                 else
                 {
-                    var firstEmptyIndex = remoteIds.FindIndex(x => x == ClearUsbValue);
+                    var firstEmptyIndex = remoteIds.FindIndex(x => x.Equals(ClearUsbValue, StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(x));
                     if (firstEmptyIndex >= 0)
                     {
                         local.LogDebug(
@@ -74,6 +80,14 @@ public static class UsbStreamExt
                             .UsbInput
                             .RemoteDeviceIds[(uint)(firstEmptyIndex + 1)]
                             .StringValue = localId;
+                    }
+                    else
+                    {
+                        local.LogDebug(
+                            "Couldn't find any available slots on local device {localKey} for remote device {remoteKey}",
+                            local.Key,
+                            remote.Key
+                        );
                     }
                 }
             }

--- a/src/NvxEpi/Features/Streams/Usb/UsbStream.cs
+++ b/src/NvxEpi/Features/Streams/Usb/UsbStream.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Crestron.SimplSharp;
+﻿using Crestron.SimplSharp;
 using Crestron.SimplSharpPro.DM.Endpoints;
 using Crestron.SimplSharpPro.DM.Streaming;
 using NvxEpi.Abstractions;
@@ -11,6 +9,9 @@ using NvxEpi.Features.Config;
 using NvxEpi.Services.Feedback;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
+using System;
+using System.Linq;
+using System.Threading;
 
 namespace NvxEpi.Features.Streams.Usb;
 
@@ -117,24 +118,25 @@ public class UsbStream : IUsbStreamWithHardware
                 ? DmNvxUsbInput.eUsbTransportMode.Layer3
                 : DmNvxUsbInput.eUsbTransportMode.Layer2;
 
-            if (!string.IsNullOrEmpty(_defaultPair) && IsRemote)
+            if (DeviceManager.GetDeviceForKey(_defaultPair) is not IUsbStreamWithHardware local)
             {
-                if (DeviceManager.GetDeviceForKey(_defaultPair) is not IUsbStreamWithHardware local)
-                {
-                    return;
-                }
+                return;
+            }
 
-                if (!hasSubscribed)
-                {
-                    local.IsOnline.OutputChange += LocalIsOnlineOutputChange;
-                    hasSubscribed = true;
-                }
+            if (!hasSubscribed)
+            {
+                var timer = new Timer(_ => SetDefaultStream(IsRemote, _defaultPair), null, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(5));
 
-                if (local.IsOnline.BoolValue)
+                CrestronEnvironment.ProgramStatusEventHandler += (type) =>
                 {
-                    this.LogInformation("Pairing default USB to {defaultPair}", _defaultPair);
-                    SetDefaultStream(IsRemote, _defaultPair);
-                }
+                    if (type == eProgramStatusEventType.Stopping)
+                    {
+                        timer.Dispose();
+                    }
+                };
+
+                hasSubscribed = true;
+                SetDefaultStream(IsRemote, _defaultPair);
             }
         };
 
@@ -161,15 +163,6 @@ public class UsbStream : IUsbStreamWithHardware
         stream.StreamUrl.OutputChange += (sender, args) => FollowCurrentRoute(args.StringValue);
     }
 
-    private void LocalIsOnlineOutputChange(object sender, FeedbackEventArgs e)
-    {
-        if (e.BoolValue)
-        {
-            this.LogInformation("Pairing default USB to {defaultPair}", _defaultPair);
-            SetDefaultStream(IsRemote, _defaultPair);
-        }
-    }
-
     void UsbInput_UsbInputChange(
         object sender,
         Crestron.SimplSharpPro.DeviceSupport.GenericEventArgs args
@@ -177,8 +170,12 @@ public class UsbStream : IUsbStreamWithHardware
     {
         if (args.EventId == UsbInputEventIds.RemoteDeviceIdFeedbackEventId)
         {
-            var feedback = _device.Feedbacks.FirstOrDefault(o => o.Key == UsbRouteFeedback.Key);
-            feedback.FireUpdate();
+            _usbRemoteIds.ToList().ForEach(kvp => kvp.Value.FireUpdate());
+        }
+
+        if (args.EventId == UsbInputEventIds.LocalDeviceIdFeedbackEventId)
+        {
+            _usbLocalId.FireUpdate();
         }
     }
 
@@ -324,6 +321,7 @@ public class UsbStream : IUsbStreamWithHardware
         if (DeviceManager.GetDeviceForKey(defaultPair) is not IUsbStreamWithHardware local)
             return;
 
+        this.LogInformation("Setting Default Stream to {defaultPair}", defaultPair);
         local.AddRemoteUsbStreamToLocal(this);
     }
 


### PR DESCRIPTION
Refactor USB pairing to use periodic timer for default device pairing, add checks for empty remote IDs, enhance slot matching logic, and improve feedback updates. Add detailed logging for pairing actions and errors. Remove online status event handler for more robust operation.