### PR TITLE
feat: add e20 type

### DIFF
--- a/src/NvxEpi/Abstractions/Hardware/INvxE20Hardware.cs
+++ b/src/NvxEpi/Abstractions/Hardware/INvxE20Hardware.cs
@@ -1,0 +1,8 @@
+using Crestron.SimplSharpPro.DM.Streaming;
+
+namespace NvxEpi.Abstractions.Hardware;
+
+public interface INvxE20Hardware : INvxHardware
+{
+    new DmNvxE20 Hardware { get; }
+}

--- a/src/NvxEpi/Abstractions/INvxE20DeviceWithHardware.cs
+++ b/src/NvxEpi/Abstractions/INvxE20DeviceWithHardware.cs
@@ -1,0 +1,8 @@
+using NvxEpi.Abstractions.Hardware;
+
+namespace NvxEpi.Abstractions;
+
+public interface INvxE20DeviceWithHardware : INvxDeviceWithHardware, INvxE20Hardware
+{
+
+}

--- a/src/NvxEpi/Devices/Nvx35x.cs
+++ b/src/NvxEpi/Devices/Nvx35x.cs
@@ -170,7 +170,23 @@ public class Nvx35X :
 
     public Cec StreamCec
     {
-        get { return Hardware.HdmiOut.StreamCec; }
+        get
+        {
+            if (IsTransmitter)
+            {
+                this.LogVerbose("CEC is not available in transmitter mode");
+                return null;
+            }
+
+            var hdmiOut = Hardware?.HdmiOut;
+            if (hdmiOut == null)
+            {
+                this.LogWarning("Unable to access StreamCec; HdmiOut is not available");
+                return null;
+            }
+
+            return hdmiOut.StreamCec;
+        }
     }
 
     public ReadOnlyDictionary<uint, BoolFeedback> SyncDetected

--- a/src/NvxEpi/Devices/Nvx36X.cs
+++ b/src/NvxEpi/Devices/Nvx36X.cs
@@ -183,7 +183,23 @@ public class Nvx36X
 
     public Cec StreamCec
     {
-        get { return Hardware.HdmiOut.StreamCec; }
+        get
+        {
+            if (IsTransmitter)
+            {
+                this.LogVerbose("CEC is not available in transmitter mode");
+                return null;
+            }
+
+            var hdmiOut = Hardware?.HdmiOut;
+            if (hdmiOut == null)
+            {
+                this.LogWarning("Unable to access StreamCec; HdmiOut is not available");
+                return null;
+            }
+
+            return hdmiOut.StreamCec;
+        }
     }
 
     public ReadOnlyDictionary<uint, BoolFeedback> SyncDetected

--- a/src/NvxEpi/Devices/Nvx38X.cs
+++ b/src/NvxEpi/Devices/Nvx38X.cs
@@ -200,7 +200,23 @@ public class Nvx38X
 
     public Cec StreamCec
     {
-        get { return Hardware.HdmiOut.StreamCec; }
+        get
+        {
+            if (IsTransmitter)
+            {
+                this.LogVerbose("CEC is not available in transmitter mode");
+                return null;
+            }
+
+            var hdmiOut = Hardware?.HdmiOut;
+            if (hdmiOut == null)
+            {
+                this.LogWarning("Unable to access StreamCec; HdmiOut is not available");
+                return null;
+            }
+
+            return hdmiOut.StreamCec;
+        }
     }
 
     public ReadOnlyDictionary<uint, BoolFeedback> SyncDetected

--- a/src/NvxEpi/Devices/NvxBaseDevice.cs
+++ b/src/NvxEpi/Devices/NvxBaseDevice.cs
@@ -411,7 +411,7 @@ public abstract class NvxBaseDevice
 
             Hardware.Control.Name.StringValue = _hardwareName;
 
-            if (IsTransmitter || hardware is DmNvxE30)
+            if (IsTransmitter || hardware is DmNvxE20 || hardware is DmNvxE30)
                 Hardware.SetTxDefaults(props);
             else
                 Hardware.SetRxDefaults(props);

--- a/src/NvxEpi/Devices/NvxD3X.cs
+++ b/src/NvxEpi/Devices/NvxD3X.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Crestron.SimplSharpPro;
 using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.DM;
 using Crestron.SimplSharpPro.DM.Streaming;
 using NvxEpi.Abstractions;
 using NvxEpi.Abstractions.HdmiOutput;
@@ -30,6 +31,7 @@ public class NvxD3X :
     IIROutputPorts,
     IHdmiOutput,
     IRoutingWithFeedback,
+    ICec,
     IBasicVolumeWithFeedback
 {
     private IBasicVolumeWithFeedback _audio;
@@ -52,7 +54,7 @@ public class NvxD3X :
         var result = base.CustomActivate();
 
         _audio = new NvxD3XAudio(hardware, this);
-        _hdmiOutput = new HdmiOutput(this);
+        _hdmiOutput = new NvxEpi.Features.Hdmi.Output.HdmiOutput(this);
 
         Feedbacks.AddRange(new[] { (Feedback)_audio.MuteFeedback, _audio.VolumeLevelFeedback });
 
@@ -95,6 +97,11 @@ public class NvxD3X :
     }
 
     public new DmNvxD3x Hardware { get; private set; }
+
+    public Cec StreamCec
+    {
+        get { return Hardware.HdmiOut.StreamCec; }
+    }
 
     public IntFeedback HorizontalResolution
     {

--- a/src/NvxEpi/Devices/NvxD3X.cs
+++ b/src/NvxEpi/Devices/NvxD3X.cs
@@ -100,7 +100,17 @@ public class NvxD3X :
 
     public Cec StreamCec
     {
-        get { return Hardware.HdmiOut.StreamCec; }
+        get
+        {
+            var hdmiOut = Hardware?.HdmiOut;
+            if (hdmiOut == null)
+            {
+                this.LogWarning("Unable to access StreamCec; HdmiOut is not available");
+                return null;
+            }
+
+            return hdmiOut.StreamCec;
+        }
     }
 
     public IntFeedback HorizontalResolution

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -52,8 +52,8 @@ public class NvxE20 :
 
             if (Hardware == null)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
-                return base.CustomActivate();
+                this.LogWarning("Hardware is null");
+                return result;
             }
 
             Hardware.BaseEvent += (o, a) =>

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.DM.Streaming;
+using NvxEpi.Abstractions;
+using NvxEpi.Abstractions.HdmiInput;
+using NvxEpi.Enums;
+using NvxEpi.Extensions;
+using NvxEpi.Services.Bridge;
+using NvxEpi.Services.InputPorts;
+using NvxEpi.Services.InputSwitching;
+using PepperDash.Core;
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+using HdmiInput = NvxEpi.Features.Hdmi.Input.HdmiInput;
+
+namespace NvxEpi.Devices;
+
+public class NvxE20 :
+    NvxBaseDevice,
+    INvxE20DeviceWithHardware,
+    IHdmiInput,
+    IRoutingWithFeedback
+{
+    private IHdmiInput _hdmiInputs;
+
+    public event RouteChangedEventHandler RouteChanged;
+
+    public NvxE20(DeviceConfig config, Func<DmNvxBaseClass> getHardware)
+        : base(config, getHardware, true)
+    {
+        AddPreActivationAction(AddRoutingPorts);
+    }
+
+    public override bool CustomActivate()
+    {
+        try
+        {
+            var hardware = base.Hardware as DmNvxE20 ?? throw new Exception("hardware built doesn't match");
+            Hardware = hardware;
+
+            var result = base.CustomActivate();
+
+            _hdmiInputs = new HdmiInput(this);
+
+            AddMcMessengers();
+
+            if (Hardware == null)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
+                return base.CustomActivate();
+            }
+
+            Hardware.BaseEvent += (o, a) =>
+            {
+                var newRoute = this.HandleBaseEvent(a);
+
+                if (newRoute == null)
+                {
+                    return;
+                }
+
+                RouteChanged?.Invoke(this, newRoute);
+            };
+
+            var inputPort = InputPorts.FirstOrDefault(p => p.Key == DeviceInputEnum.Hdmi1.Name);
+
+            var outputPort = OutputPorts.FirstOrDefault(p => p.Key == SwitcherForStreamOutput.Key);
+
+            if (inputPort == null || outputPort == null)
+            {
+                this.LogWarning("Unable to find input or output port for initial route. Input Port: {inputPort} Output Port: {outputPort}", inputPort, outputPort);
+                return result;
+            }
+
+            var currentRoute = new RouteSwitchDescriptor(outputPort, inputPort);
+            CurrentRoutes.Add(currentRoute);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Debug.LogMessage(ex, "Exception activating device", this);
+            return false;
+        }
+    }
+
+    public new DmNvxE20 Hardware { get; private set; }
+
+    public ReadOnlyDictionary<uint, IntFeedback> HdcpCapability
+    {
+        get { return _hdmiInputs.HdcpCapability; }
+    }
+
+    public ReadOnlyDictionary<uint, BoolFeedback> SyncDetected
+    {
+        get { return _hdmiInputs.SyncDetected; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> CurrentResolution
+    {
+        get { return _hdmiInputs.CurrentResolution; }
+    }
+
+    public ReadOnlyDictionary<uint, IntFeedback> AudioChannels
+    {
+        get { return _hdmiInputs.AudioChannels; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> AudioFormat
+    {
+        get { return _hdmiInputs.AudioFormat; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> ColorSpace
+    {
+        get { return _hdmiInputs.ColorSpace; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdrType
+    {
+        get { return _hdmiInputs.HdrType; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdcpCapabilityString { get { return _hdmiInputs.HdcpCapabilityString; } }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdcpSupport { get { return _hdmiInputs.HdcpSupport; } }
+
+    public List<RouteSwitchDescriptor> CurrentRoutes { get; } = new();
+
+    public void ExecuteSwitch(object inputSelector, object outputSelector, eRoutingSignalType signalType)
+    {
+        try
+        {
+            if (outputSelector is not IHandleInputSwitch switcher)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Error, "Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", this, outputSelector.ToString());
+                return;
+            }
+
+            Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
+
+            if (inputSelector is null)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Information, "Device is DmNvxE20. 'None' input not available", this);
+                return;
+            }
+
+            switcher.HandleSwitch(inputSelector, signalType);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogMessage(ex, "Error executing switch!", this);
+        }
+    }
+
+    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+    {
+        var deviceBridge = new NvxDeviceBridge(this);
+        deviceBridge.LinkToApi(trilist, joinStart, joinMapKey, bridge);
+    }
+
+    private void AddRoutingPorts()
+    {
+        HdmiInput1Port.AddRoutingPort(this);
+        SwitcherForStreamOutput.AddRoutingPort(this);
+        AnalogAudioInput.AddRoutingPort(this);
+        SecondaryAudioInput.AddRoutingPort(this);
+        SwitcherForSecondaryAudioOutput.AddRoutingPort(this);
+    }
+}

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -85,7 +85,8 @@ public class NvxE20 :
         }
         catch (Exception ex)
         {
-            Debug.LogMessage(ex, "Exception activating device", this);
+            this.LogError(ex, "Exception activating device");
+            this.LogVerbose(ex.Message);
             return false;
         }
     }
@@ -139,15 +140,16 @@ public class NvxE20 :
         {
             if (outputSelector is not IHandleInputSwitch switcher)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Error, "Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", this, outputSelector.ToString());
+                var outputSelectorType = outputSelector?.GetType().FullName ?? "null";
+                this.LogError("Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", outputSelectorType);
                 return;
             }
 
-            Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
+            this.LogDebug("Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
 
             if (inputSelector is null)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Information, "Device is DmNvxE20. 'None' input not available", this);
+                this.LogInformation("Device is DmNvxE20. 'None' input not available");
                 return;
             }
 
@@ -155,7 +157,8 @@ public class NvxE20 :
         }
         catch (Exception ex)
         {
-            Debug.LogMessage(ex, "Error executing switch!", this);
+            this.LogError(ex, "Error executing switch!");
+            this.LogVerbose(ex.Message);
         }
     }
 

--- a/src/NvxEpi/Devices/NvxE3X.cs
+++ b/src/NvxEpi/Devices/NvxE3X.cs
@@ -55,7 +55,7 @@ public class NvxE3X :
             if (Hardware == null)
             {
                 Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
-                return base.CustomActivate();
+                return result;
             }
 
             Hardware.BaseEvent += (o, a) =>

--- a/src/NvxEpi/Extensions/VideoInputExtensions.cs
+++ b/src/NvxEpi/Extensions/VideoInputExtensions.cs
@@ -37,7 +37,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToHdmiInput1(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -47,7 +47,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToHdmiInput2(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -57,7 +57,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToUsbcInput1(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -67,7 +67,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToUsbcInput2(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -77,7 +77,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToInputNone(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -87,7 +87,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToStream(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x || device.IsTransmitter)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x || device.IsTransmitter)
         {
             return;
         }

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -225,7 +225,6 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         };
                     }
                 case "dmnvxe20":
-                case "dmnvxe202g":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
@@ -239,6 +238,22 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                             return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
                                 ? new DmNvxE20((uint)props.DeviceId, domain)
                                 : new DmNvxE20((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
+                        };
+                    }
+                case "dmnvxe202g":
+                    {
+                        if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
+                            props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                        }
+                        return () =>
+                        {
+                            var xio = GetDirector(props.ParentDeviceKey);
+
+                            return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
+                                ? new DmNvxE202g((uint)props.DeviceId, domain)
+                                : new DmNvxE202g((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
                         };
                     }
                 case "dmnvxe30":

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -224,6 +224,22 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                                 : new DmNvxD30C((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
                         };
                     }
+                case "dmnvxe20":
+                    {
+                        if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
+                            props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                        }
+                        return () =>
+                        {
+                            var xio = GetDirector(props.ParentDeviceKey);
+
+                            return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
+                                ? new DmNvxE20((uint)props.DeviceId, domain)
+                                : new DmNvxE20((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
+                        };
+                    }
                 case "dmnvxe30":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -225,6 +225,7 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         };
                     }
                 case "dmnvxe20":
+                case "dmnvxe202g":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -245,7 +245,7 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
                         {
-                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                            return () => new DmNvxE202g(props.Control.IpIdInt, Global.ControlSystem);
                         }
                         return () =>
                         {

--- a/src/NvxEpi/Factories/NvxE20DeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxE20DeviceFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Features.Config;
@@ -7,20 +7,18 @@ using PepperDash.Essentials.Core.Config;
 
 namespace NvxEpi.Factories;
 
-public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
+public class NvxE20DeviceFactory : NvxBaseDeviceFactory<NvxE20>
 {
     private static List<string> _typeNames;
 
-    public NvxE3XDeviceFactory()
+    public NvxE20DeviceFactory()
     {
         MinimumEssentialsFrameworkVersion = MinumumEssentialsVersion;
 
         _typeNames ??= new List<string>
             {
-                "dmnvxe30",
-                "dmnvxe30c",
-                "dmnvxe31",
-                "dmnvxe31c",
+                "dmnvxe20",
+                "dmnvxe202g"
             };
 
         TypeNames = _typeNames.ToList();
@@ -30,6 +28,6 @@ public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
     {
         var props = NvxDeviceProperties.FromDeviceConfig(dc);
         var deviceBuild = GetDeviceBuildAction(dc.Type, props);
-        return new NvxE3X(dc, deviceBuild);
+        return new NvxE20(dc, deviceBuild);
     }
 }

--- a/src/NvxEpi/Factories/NvxE3XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxE3XDeviceFactory.cs
@@ -17,6 +17,7 @@ public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
 
         _typeNames ??= new List<string>
             {
+                "dmnvxe20",
                 "dmnvxe30",
                 "dmnvxe30c",
                 "dmnvxe31",

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -153,18 +153,18 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
                 .ToDictionary(i => i.Key, i => i);
 
             this.LogDebug("Mock Device inputs: {count}", mockInputSlots.Count);
-            this.LogDebug("Real Device inputs: {count}", InputSlots.Count);
+            this.LogDebug("Real Device inputs: {count}", _inputSlots.Count);
 
             foreach (var kvp in mockInputSlots)
             {
-                InputSlots[kvp.Key] = kvp.Value;
+                _inputSlots[kvp.Key] = kvp.Value;
             }
 
-            this.LogDebug("Total input: {count}", InputSlots.Count);
+            this.LogDebug("Total input: {count}", _inputSlots.Count);
 
             var clearInput = new NvxMatrixClearInput();
 
-            InputSlots.Add(clearInput.Key, clearInput);
+            _inputSlots.Add(clearInput.Key, clearInput);
 
             _outputSlots = DeviceManager
                 .AllDevices.OfType<NvxBaseDevice>()

--- a/src/NvxEpi/Services/Feedback/DeviceModeFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/DeviceModeFeedback.cs
@@ -10,12 +10,12 @@ public class DeviceModeFeedback
     public static IntFeedback GetFeedback(DmNvxBaseClass device)
     {
         if (device is DmNvxD3x)
-            return new IntFeedback(Key, () => (int) eDeviceMode.Receiver);
+            return new IntFeedback(Key, () => (int)eDeviceMode.Receiver);
 
-        if (device is DmNvxE3x)
-            return new IntFeedback(Key, () => (int) eDeviceMode.Transmitter);
+        if (device is DmNvxE3x || device is DmNvxE20)
+            return new IntFeedback(Key, () => (int)eDeviceMode.Transmitter);
 
-        var feedback = new IntFeedback(Key, () => (int) device.Control.DeviceModeFeedback);
+        var feedback = new IntFeedback(Key, () => (int)device.Control.DeviceModeFeedback);
         device.BaseEvent += (@base, args) => feedback.FireUpdate();
 
         return feedback;

--- a/src/NvxEpi/Services/Feedback/StreamUrlFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/StreamUrlFeedback.cs
@@ -21,6 +21,10 @@ public class StreamUrlFeedback
         {
             (device as DmNvxE3x).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();
         }
+        else if (device is DmNvxE20)
+        {
+            (device as DmNvxE20).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();
+        }
         else if (device is DmNvxE760x)
         {
             (device as DmNvxE760x).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();

--- a/src/NvxEpi/Services/InputSwitching/SwitcherForStreamOutput.cs
+++ b/src/NvxEpi/Services/InputSwitching/SwitcherForStreamOutput.cs
@@ -57,6 +57,10 @@ public class SwitcherForStreamOutput : IHandleInputSwitch
             _device.SetVideoToHdmiInput1();
         else if (input == DeviceInputEnum.Hdmi2)
             _device.SetVideoToHdmiInput2();
+        else if (input == DeviceInputEnum.Usbc1)
+            _device.SetVideoToUsbcInput1();
+        else if (input == DeviceInputEnum.Usbc2)
+            _device.SetVideoToUsbcInput2();
         else if (input == DeviceInputEnum.Automatic)
             _device.SetVideoToAutomatic();
         else
@@ -75,6 +79,8 @@ public class SwitcherForStreamOutput : IHandleInputSwitch
             deviceWithAudioSwitching.SetAudioToHdmiInput1();
         else if (input == DeviceInputEnum.Hdmi2)
             deviceWithAudioSwitching.SetAudioToHdmiInput2();
+        else if (input == DeviceInputEnum.Usbc1 || input == DeviceInputEnum.Usbc2)
+            deviceWithAudioSwitching.SetAudioToInputAutomatic();
         else
             throw new NotSupportedException(input.Name);
     }

--- a/src/NvxEpi/Services/Utilities/DeviceDefaults.cs
+++ b/src/NvxEpi/Services/Utilities/DeviceDefaults.cs
@@ -9,7 +9,7 @@ public static class DeviceDefaults
 {
     public static void SetTxDefaults(this DmNvxBaseClass device, NvxDeviceProperties props)
     {
-        if (device is not DmNvxE3x)
+        if (device is not DmNvxE3x && device is not DmNvxE20)
         {
             device.Control.DeviceMode = eDeviceMode.Transmitter;
         }


### PR DESCRIPTION
This pull request adds support for the `DmNvxE20` device across the codebase, ensuring it is recognized and handled similarly to other NVX E-series devices. The main changes include updating device registration logic, factory creation methods, and supported device type lists.

**Device support and registration:**

* Added `"dmnvxe20"` to the list of supported device types in the `NvxE3XDeviceFactory` constructor, enabling the factory to recognize and handle the E20 device.
* Updated the `GetDeviceBuildAction` method in `NvxBaseDeviceFactory` to include logic for constructing and initializing a `DmNvxE20` device, mirroring the approach used for other device types.

**Device configuration logic:**

* Modified the `RegisterForOnlineFeedback` method in `NvxBaseDevice` to treat `DmNvxE20` as a transmitter, ensuring the correct default configuration is applied.