### PR TITLE
Add E20 type

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ noSwitch
 
 ```json
 {
-    "key": "NvxRouter",
+    "key": "nvx-router",
     "name": "NvxRouter",
     "type": "dynNvx",
     "group": "nvx",

--- a/src/NvxEpi/Abstractions/Hardware/INvxE20Hardware.cs
+++ b/src/NvxEpi/Abstractions/Hardware/INvxE20Hardware.cs
@@ -1,0 +1,8 @@
+using Crestron.SimplSharpPro.DM.Streaming;
+
+namespace NvxEpi.Abstractions.Hardware;
+
+public interface INvxE20Hardware : INvxHardware
+{
+    new DmNvxE20 Hardware { get; }
+}

--- a/src/NvxEpi/Abstractions/INvxDevice.cs
+++ b/src/NvxEpi/Abstractions/INvxDevice.cs
@@ -7,5 +7,6 @@ namespace NvxEpi.Abstractions;
 public interface INvxDevice : IRoutingInputsOutputs,
     IHasFeedback, IOnline, ITransmitterReceiver, IKeyName, IDeviceId
 {
-
+    bool IsEnabled { get; }
+    BoolFeedback EnabledFeedback { get; }
 }

--- a/src/NvxEpi/Abstractions/INvxE20DeviceWithHardware.cs
+++ b/src/NvxEpi/Abstractions/INvxE20DeviceWithHardware.cs
@@ -1,0 +1,8 @@
+using NvxEpi.Abstractions.Hardware;
+
+namespace NvxEpi.Abstractions;
+
+public interface INvxE20DeviceWithHardware : INvxDeviceWithHardware, INvxE20Hardware
+{
+
+}

--- a/src/NvxEpi/Devices/NvxBaseDevice.cs
+++ b/src/NvxEpi/Devices/NvxBaseDevice.cs
@@ -411,7 +411,7 @@ public abstract class NvxBaseDevice
 
             Hardware.Control.Name.StringValue = _hardwareName;
 
-            if (IsTransmitter || hardware is DmNvxE30)
+            if (IsTransmitter || hardware is DmNvxE20 || hardware is DmNvxE30)
                 Hardware.SetTxDefaults(props);
             else
                 Hardware.SetRxDefaults(props);

--- a/src/NvxEpi/Devices/NvxD3X.cs
+++ b/src/NvxEpi/Devices/NvxD3X.cs
@@ -6,7 +6,6 @@ using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM.Streaming;
 using NvxEpi.Abstractions;
 using NvxEpi.Abstractions.HdmiOutput;
-using NvxEpi.Abstractions.Usb;
 using NvxEpi.Enums;
 using NvxEpi.Extensions;
 using NvxEpi.Features.Audio;
@@ -34,7 +33,6 @@ public class NvxD3X :
 {
     private IBasicVolumeWithFeedback _audio;
     private IHdmiOutput _hdmiOutput;
-    private readonly IUsbStream _usbStream;
 
     public event RouteChangedEventHandler RouteChanged;
 
@@ -114,11 +112,6 @@ public class NvxD3X :
     public CrestronCollection<IROutputPort> IROutputPorts
     {
         get { return Hardware.IROutputPorts; }
-    }
-
-    public bool IsRemote
-    {
-        get { return _usbStream.IsRemote; }
     }
 
     public int NumberOfComPorts

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -52,8 +52,8 @@ public class NvxE20 :
 
             if (Hardware == null)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
-                return base.CustomActivate();
+                this.LogWarning("Hardware is null");
+                return result;
             }
 
             Hardware.BaseEvent += (o, a) =>

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.DM.Streaming;
+using NvxEpi.Abstractions;
+using NvxEpi.Abstractions.HdmiInput;
+using NvxEpi.Enums;
+using NvxEpi.Extensions;
+using NvxEpi.Services.Bridge;
+using NvxEpi.Services.InputPorts;
+using NvxEpi.Services.InputSwitching;
+using PepperDash.Core;
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+using HdmiInput = NvxEpi.Features.Hdmi.Input.HdmiInput;
+
+namespace NvxEpi.Devices;
+
+public class NvxE20 :
+    NvxBaseDevice,
+    INvxE20DeviceWithHardware,
+    IHdmiInput,
+    IRoutingWithFeedback
+{
+    private IHdmiInput _hdmiInputs;
+
+    public event RouteChangedEventHandler RouteChanged;
+
+    public NvxE20(DeviceConfig config, Func<DmNvxBaseClass> getHardware)
+        : base(config, getHardware, true)
+    {
+        AddPreActivationAction(AddRoutingPorts);
+    }
+
+    public override bool CustomActivate()
+    {
+        try
+        {
+            var hardware = base.Hardware as DmNvxE20 ?? throw new Exception("hardware built doesn't match");
+            Hardware = hardware;
+
+            var result = base.CustomActivate();
+
+            _hdmiInputs = new HdmiInput(this);
+
+            AddMcMessengers();
+
+            if (Hardware == null)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
+                return base.CustomActivate();
+            }
+
+            Hardware.BaseEvent += (o, a) =>
+            {
+                var newRoute = this.HandleBaseEvent(a);
+
+                if (newRoute == null)
+                {
+                    return;
+                }
+
+                RouteChanged?.Invoke(this, newRoute);
+            };
+
+            var inputPort = InputPorts.FirstOrDefault(p => p.Key == DeviceInputEnum.Hdmi1.Name);
+
+            var outputPort = OutputPorts.FirstOrDefault(p => p.Key == SwitcherForStreamOutput.Key);
+
+            if (inputPort == null || outputPort == null)
+            {
+                this.LogWarning("Unable to find input or output port for initial route. Input Port: {inputPort} Output Port: {outputPort}", inputPort, outputPort);
+                return result;
+            }
+
+            var currentRoute = new RouteSwitchDescriptor(outputPort, inputPort);
+            CurrentRoutes.Add(currentRoute);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Debug.LogMessage(ex, "Exception activating device", this);
+            return false;
+        }
+    }
+
+    public new DmNvxE20 Hardware { get; private set; }
+
+    public ReadOnlyDictionary<uint, IntFeedback> HdcpCapability
+    {
+        get { return _hdmiInputs.HdcpCapability; }
+    }
+
+    public ReadOnlyDictionary<uint, BoolFeedback> SyncDetected
+    {
+        get { return _hdmiInputs.SyncDetected; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> CurrentResolution
+    {
+        get { return _hdmiInputs.CurrentResolution; }
+    }
+
+    public ReadOnlyDictionary<uint, IntFeedback> AudioChannels
+    {
+        get { return _hdmiInputs.AudioChannels; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> AudioFormat
+    {
+        get { return _hdmiInputs.AudioFormat; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> ColorSpace
+    {
+        get { return _hdmiInputs.ColorSpace; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdrType
+    {
+        get { return _hdmiInputs.HdrType; }
+    }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdcpCapabilityString { get { return _hdmiInputs.HdcpCapabilityString; } }
+
+    public ReadOnlyDictionary<uint, StringFeedback> HdcpSupport { get { return _hdmiInputs.HdcpSupport; } }
+
+    public List<RouteSwitchDescriptor> CurrentRoutes { get; } = new();
+
+    public void ExecuteSwitch(object inputSelector, object outputSelector, eRoutingSignalType signalType)
+    {
+        try
+        {
+            if (outputSelector is not IHandleInputSwitch switcher)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Error, "Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", this, outputSelector.ToString());
+                return;
+            }
+
+            Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
+
+            if (inputSelector is null)
+            {
+                Debug.LogMessage(Serilog.Events.LogEventLevel.Information, "Device is DmNvxE20. 'None' input not available", this);
+                return;
+            }
+
+            switcher.HandleSwitch(inputSelector, signalType);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogMessage(ex, "Error executing switch!", this);
+        }
+    }
+
+    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+    {
+        var deviceBridge = new NvxDeviceBridge(this);
+        deviceBridge.LinkToApi(trilist, joinStart, joinMapKey, bridge);
+    }
+
+    private void AddRoutingPorts()
+    {
+        HdmiInput1Port.AddRoutingPort(this);
+        SwitcherForStreamOutput.AddRoutingPort(this);
+        AnalogAudioInput.AddRoutingPort(this);
+        SecondaryAudioInput.AddRoutingPort(this);
+        SwitcherForSecondaryAudioOutput.AddRoutingPort(this);
+    }
+}

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -85,7 +85,8 @@ public class NvxE20 :
         }
         catch (Exception ex)
         {
-            Debug.LogMessage(ex, "Exception activating device", this);
+            this.LogError(ex, "Exception activating device");
+            this.LogVerbose(ex.Message);
             return false;
         }
     }
@@ -139,15 +140,16 @@ public class NvxE20 :
         {
             if (outputSelector is not IHandleInputSwitch switcher)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Error, "Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", this, outputSelector.ToString());
+                var outputSelectorType = outputSelector?.GetType().FullName ?? "null";
+                this.LogError("Unable to execute switch. OutputSelector is not IHandleInputSwitch {outputSelectorType}", outputSelectorType);
                 return;
             }
 
-            Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
+            this.LogDebug("Switching {input} to {output} type {type}", inputSelector, outputSelector, signalType.ToString());
 
             if (inputSelector is null)
             {
-                Debug.LogMessage(Serilog.Events.LogEventLevel.Information, "Device is DmNvxE20. 'None' input not available", this);
+                this.LogInformation("Device is DmNvxE20. 'None' input not available");
                 return;
             }
 
@@ -155,7 +157,8 @@ public class NvxE20 :
         }
         catch (Exception ex)
         {
-            Debug.LogMessage(ex, "Error executing switch!", this);
+            this.LogError(ex, "Error executing switch!");
+            this.LogVerbose(ex.Message);
         }
     }
 

--- a/src/NvxEpi/Devices/NvxE3X.cs
+++ b/src/NvxEpi/Devices/NvxE3X.cs
@@ -7,7 +7,6 @@ using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM.Streaming;
 using NvxEpi.Abstractions;
 using NvxEpi.Abstractions.HdmiInput;
-using NvxEpi.Abstractions.Usb;
 using NvxEpi.Enums;
 using NvxEpi.Extensions;
 using NvxEpi.Services.Bridge;
@@ -31,7 +30,6 @@ public class NvxE3X :
     IRoutingWithFeedback
 {
     private IHdmiInput _hdmiInputs;
-    private readonly IUsbStream _usbStream;
 
     public event RouteChangedEventHandler RouteChanged;
 
@@ -109,11 +107,6 @@ public class NvxE3X :
     public CrestronCollection<IROutputPort> IROutputPorts
     {
         get { return Hardware.IROutputPorts; }
-    }
-
-    public bool IsRemote
-    {
-        get { return _usbStream.IsRemote; }
     }
 
     public int NumberOfComPorts

--- a/src/NvxEpi/Devices/NvxE3X.cs
+++ b/src/NvxEpi/Devices/NvxE3X.cs
@@ -55,7 +55,7 @@ public class NvxE3X :
             if (Hardware == null)
             {
                 Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "Hardware is null", this);
-                return base.CustomActivate();
+                return result;
             }
 
             Hardware.BaseEvent += (o, a) =>

--- a/src/NvxEpi/Devices/NvxMockDevice.cs
+++ b/src/NvxEpi/Devices/NvxMockDevice.cs
@@ -224,4 +224,9 @@ public class NvxMockDevice : ReconfigurableDevice, IStream, ISecondaryAudioStrea
         trilist.SetStringSigAction(joinMap.StreamUrl.JoinNumber, SetStreamUrl);
 
     }
+
+
+    public bool IsEnabled => true;
+
+    public BoolFeedback EnabledFeedback { get; } = new BoolFeedback("EnabledFeedback", () => true);
 }

--- a/src/NvxEpi/Extensions/VideoInputExtensions.cs
+++ b/src/NvxEpi/Extensions/VideoInputExtensions.cs
@@ -37,7 +37,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToHdmiInput1(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -47,7 +47,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToHdmiInput2(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -57,7 +57,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToUsbcInput1(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -67,7 +67,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToUsbcInput2(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -77,7 +77,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToInputNone(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
         {
             return;
         }
@@ -87,7 +87,7 @@ public static class VideoInputExtensions
 
     public static void SetVideoToStream(this ICurrentVideoInput device)
     {
-        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxD3x || device.IsTransmitter)
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x || device.IsTransmitter)
         {
             return;
         }

--- a/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Features.Config;
+using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 
@@ -28,9 +30,23 @@ public class Nvx36XDeviceFactory : NvxBaseDeviceFactory<Nvx36X>
         TypeNames = _typeNames.ToList();
     }
 
+    private static readonly string[] _usbUnsupportedTypes = { "dmnvxe760", "dmnvxe760c" };
+
+    private static void WarnIfUsbConfiguredOnUnsupportedDevice(DeviceConfig dc, NvxDeviceProperties props)
+    {
+        if (props.Usb == null)
+            return;
+
+        var isUnsupported = Array.Exists(_usbUnsupportedTypes, t => t.Equals(dc.Type, StringComparison.OrdinalIgnoreCase));
+
+        if (isUnsupported)
+            Debug.LogError("Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
+    }
+
     public override EssentialsDevice BuildDevice(DeviceConfig dc)
     {
         var props = NvxDeviceProperties.FromDeviceConfig(dc);
+        WarnIfUsbConfiguredOnUnsupportedDevice(dc, props);
         var deviceBuild = GetDeviceBuildAction(dc.Type, props);
         return new Nvx36X(dc, deviceBuild, props.DeviceIsTransmitter());
     }

--- a/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
@@ -6,6 +6,7 @@ using NvxEpi.Features.Config;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
+using Serilog.Events;
 
 namespace NvxEpi.Factories;
 
@@ -40,7 +41,7 @@ public class Nvx36XDeviceFactory : NvxBaseDeviceFactory<Nvx36X>
         var isUnsupported = Array.Exists(_usbUnsupportedTypes, t => t.Equals(dc.Type, StringComparison.OrdinalIgnoreCase));
 
         if (isUnsupported)
-            Debug.LogError("Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
+            Debug.LogMessage(LogEventLevel.Warning, "Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
     }
 
     public override EssentialsDevice BuildDevice(DeviceConfig dc)

--- a/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/Nvx36XDeviceFactory.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Features.Config;
+using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
+using Serilog.Events;
 
 namespace NvxEpi.Factories;
 
@@ -28,9 +31,23 @@ public class Nvx36XDeviceFactory : NvxBaseDeviceFactory<Nvx36X>
         TypeNames = _typeNames.ToList();
     }
 
+    private static readonly string[] _usbUnsupportedTypes = { "dmnvxe760", "dmnvxe760c" };
+
+    private static void WarnIfUsbConfiguredOnUnsupportedDevice(DeviceConfig dc, NvxDeviceProperties props)
+    {
+        if (props.Usb == null)
+            return;
+
+        var isUnsupported = Array.Exists(_usbUnsupportedTypes, t => t.Equals(dc.Type, StringComparison.OrdinalIgnoreCase));
+
+        if (isUnsupported)
+            Debug.LogMessage(LogEventLevel.Warning, "Device '{key}' of type '{type}' does not support USB, but USB is configured in config. USB configuration will be ignored.", dc.Key, dc.Type);
+    }
+
     public override EssentialsDevice BuildDevice(DeviceConfig dc)
     {
         var props = NvxDeviceProperties.FromDeviceConfig(dc);
+        WarnIfUsbConfiguredOnUnsupportedDevice(dc, props);
         var deviceBuild = GetDeviceBuildAction(dc.Type, props);
         return new Nvx36X(dc, deviceBuild, props.DeviceIsTransmitter());
     }

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -225,7 +225,6 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         };
                     }
                 case "dmnvxe20":
-                case "dmnvxe202g":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
@@ -239,6 +238,22 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                             return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
                                 ? new DmNvxE20((uint)props.DeviceId, domain)
                                 : new DmNvxE20((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
+                        };
+                    }
+                case "dmnvxe202g":
+                    {
+                        if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
+                            props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                        }
+                        return () =>
+                        {
+                            var xio = GetDirector(props.ParentDeviceKey);
+
+                            return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
+                                ? new DmNvxE202g((uint)props.DeviceId, domain)
+                                : new DmNvxE202g((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
                         };
                     }
                 case "dmnvxe30":

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -224,6 +224,22 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                                 : new DmNvxD30C((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
                         };
                     }
+                case "dmnvxe20":
+                    {
+                        if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
+                            props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                        }
+                        return () =>
+                        {
+                            var xio = GetDirector(props.ParentDeviceKey);
+
+                            return xio.Hardware.Domain.TryGetValue(props.DomainId, out DmXioDirectorBase.DmXioDomain domain)
+                                ? new DmNvxE20((uint)props.DeviceId, domain)
+                                : new DmNvxE20((uint)props.DeviceId, xio.Hardware.Domain.Values.FirstOrDefault());
+                        };
+                    }
                 case "dmnvxe30":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -12,7 +12,7 @@ namespace NvxEpi.Factories;
 
 public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T> where T : EssentialsDevice
 {
-    public const string MinumumEssentialsVersion = "2.24.4";
+    public const string MinumumEssentialsVersion = "2.28.0";
 
     static NvxBaseDeviceFactory()
     {

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -225,6 +225,7 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         };
                     }
                 case "dmnvxe20":
+                case "dmnvxe202g":
                     {
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -245,7 +245,7 @@ public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T>
                         if (string.IsNullOrEmpty(props.ParentDeviceKey) ||
                             props.ParentDeviceKey.Equals("processor", StringComparison.OrdinalIgnoreCase))
                         {
-                            return () => new DmNvxE20(props.Control.IpIdInt, Global.ControlSystem);
+                            return () => new DmNvxE202g(props.Control.IpIdInt, Global.ControlSystem);
                         }
                         return () =>
                         {

--- a/src/NvxEpi/Factories/NvxE20DeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxE20DeviceFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NvxEpi.Devices;
 using NvxEpi.Features.Config;
@@ -7,20 +7,18 @@ using PepperDash.Essentials.Core.Config;
 
 namespace NvxEpi.Factories;
 
-public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
+public class NvxE20DeviceFactory : NvxBaseDeviceFactory<NvxE20>
 {
     private static List<string> _typeNames;
 
-    public NvxE3XDeviceFactory()
+    public NvxE20DeviceFactory()
     {
         MinimumEssentialsFrameworkVersion = MinumumEssentialsVersion;
 
         _typeNames ??= new List<string>
             {
-                "dmnvxe30",
-                "dmnvxe30c",
-                "dmnvxe31",
-                "dmnvxe31c",
+                "dmnvxe20",
+                "dmnvxe202g"
             };
 
         TypeNames = _typeNames.ToList();
@@ -30,6 +28,6 @@ public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
     {
         var props = NvxDeviceProperties.FromDeviceConfig(dc);
         var deviceBuild = GetDeviceBuildAction(dc.Type, props);
-        return new NvxE3X(dc, deviceBuild);
+        return new NvxE20(dc, deviceBuild);
     }
 }

--- a/src/NvxEpi/Factories/NvxE3XDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxE3XDeviceFactory.cs
@@ -17,6 +17,7 @@ public class NvxE3XDeviceFactory : NvxBaseDeviceFactory<NvxE3X>
 
         _typeNames ??= new List<string>
             {
+                "dmnvxe20",
                 "dmnvxe30",
                 "dmnvxe30c",
                 "dmnvxe31",

--- a/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
+++ b/src/NvxEpi/Features/Config/NvxDeviceProperties.cs
@@ -24,6 +24,12 @@ public class NvxDeviceProperties
     public string DefaultVideoInput { get; set; }
     public bool EnableAutoRoute { get; set; }
     public string DefaultMulticastSource { get; set; }
+    public NvxEnableMatchingProperties EnableMatching { get; set; }
+}
+
+public class NvxEnableMatchingProperties
+{
+    public string DefaultGateway { get; set; }
 }
 
 public class NvxMockDeviceProperties : BaseStreamingDeviceProperties

--- a/src/NvxEpi/Features/Hdmi/Input/HdmiInput.cs
+++ b/src/NvxEpi/Features/Hdmi/Input/HdmiInput.cs
@@ -18,14 +18,16 @@ public class HdmiInput : HdmiInputBase
 
                 Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "Hardware is DmNvxE760x", this);
                 var capability = DmHdcpCapabilityValueFeedback.GetFeedback(device.Hardware);
-
                 var sync = DmSyncDetectedFeedback.GetFeedback(device.Hardware);
+                var currentResolution = DmCurrentResolutionFeedback.GetFeedback(device.Hardware);
 
                 _capability.Add(1, capability);
                 _sync.Add(1, sync);
+                _currentResolution.Add(1, currentResolution);
 
                 Feedbacks.Add(capability);
                 Feedbacks.Add(sync);
+                Feedbacks.Add(currentResolution);
 
                 return;
             }

--- a/src/NvxEpi/Features/Hdmi/Input/HdmiInputBase.cs
+++ b/src/NvxEpi/Features/Hdmi/Input/HdmiInputBase.cs
@@ -111,4 +111,8 @@ public abstract class HdmiInputBase : IHdmiInput
     public ReadOnlyDictionary<uint, StringFeedback> HdrType { get { return new ReadOnlyDictionary<uint, StringFeedback>(_hdrType); } }
 
     public ReadOnlyDictionary<uint, StringFeedback> HdcpSupport { get { return new ReadOnlyDictionary<uint, StringFeedback>(_hdcpSupport); } }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/Hdmi/Output/HdmiOutput.cs
+++ b/src/NvxEpi/Features/Hdmi/Output/HdmiOutput.cs
@@ -81,5 +81,9 @@ public class HdmiOutput : IHdmiOutput
     public int DeviceId
     {
         get { return _device.DeviceId; }
-    }         
+    }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/InputSwitching/AudioInputSwitcher.cs
+++ b/src/NvxEpi/Features/InputSwitching/AudioInputSwitcher.cs
@@ -82,4 +82,8 @@ public class AudioInputSwitcher : ICurrentAudioInput
     {
         get { return _device.OutputPorts; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/InputSwitching/DanteInputSwitcher.cs
+++ b/src/NvxEpi/Features/InputSwitching/DanteInputSwitcher.cs
@@ -73,4 +73,8 @@ public class DanteInputSwitcher : ICurrentDanteInput
 
     public StringFeedback CurrentDanteInput { get; private set; }
     public IntFeedback CurrentDanteInputValue { get; private set; }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/InputSwitching/NaxInputSwitcher.cs
+++ b/src/NvxEpi/Features/InputSwitching/NaxInputSwitcher.cs
@@ -82,4 +82,8 @@ public class NaxInputSwitcher : ICurrentNaxInput
     {
         get { return _device.OutputPorts; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/InputSwitching/VideoInputSwitcher.cs
+++ b/src/NvxEpi/Features/InputSwitching/VideoInputSwitcher.cs
@@ -82,4 +82,8 @@ public class VideoInputSwitcher : ICurrentVideoInput
     {
         get { return _device.OutputPorts; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -44,8 +44,8 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
         AddPostActivationAction(BuildMatrixRouting);
 
-        InputSlots = new Dictionary<string, IRoutingInputSlot>();
-        OutputSlots = new Dictionary<string, IRoutingOutputSlot>();
+        //InputSlots = new Dictionary<string, IRoutingInputSlot>();
+        //OutputSlots = new Dictionary<string, IRoutingOutputSlot>();
     }
 
     public static NvxGlobalRouter Instance
@@ -121,16 +121,18 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
             .ToDictionary(
                 kvp => kvp.Key,
                 kvp => kvp.Value);
-    public Dictionary<string, IRoutingOutputSlot> OutputSlots => _outputSlots.Where(kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
+    public Dictionary<string, IRoutingOutputSlot> OutputSlots => _outputSlots.Where(
+        kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
             .ToDictionary(
                 kvp => kvp.Key,
                 kvp => kvp.Value);
+
 
     private void BuildMatrixRouting()
     {
         try
         {
-            InputSlots = DeviceManager
+            _inputSlots = DeviceManager
                 .AllDevices.OfType<NvxBaseDevice>()
                 .Where(t => t.IsTransmitter)
                 .Select(t =>
@@ -164,7 +166,7 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
             InputSlots.Add(clearInput.Key, clearInput);
 
-            OutputSlots = DeviceManager
+            _outputSlots = DeviceManager
                 .AllDevices.OfType<NvxBaseDevice>()
                 .Where(t => !t.IsTransmitter)
                 .Select((t) => new NvxMatrixOutput(t))

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -153,18 +153,18 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
                 .ToDictionary(i => i.Key, i => i);
 
             this.LogDebug("Mock Device inputs: {count}", mockInputSlots.Count);
-            this.LogDebug("Real Device inputs: {count}", InputSlots.Count);
+            this.LogDebug("Real Device inputs: {count}", _inputSlots.Count);
 
             foreach (var kvp in mockInputSlots)
             {
-                InputSlots[kvp.Key] = kvp.Value;
+                _inputSlots[kvp.Key] = kvp.Value;
             }
 
-            this.LogDebug("Total input: {count}", InputSlots.Count);
+            this.LogDebug("Total input: {count}", _inputSlots.Count);
 
             var clearInput = new NvxMatrixClearInput();
 
-            InputSlots.Add(clearInput.Key, clearInput);
+            _inputSlots.Add(clearInput.Key, clearInput);
 
             _outputSlots = DeviceManager
                 .AllDevices.OfType<NvxBaseDevice>()

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -116,11 +116,11 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
     private Dictionary<string, IRoutingInputSlot> _inputSlots = new();
     private Dictionary<string, IRoutingOutputSlot> _outputSlots = new();
-    public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(
-        kvp => (kvp.Value is NvxMatrixInput input && input.IsEnabled) || kvp.Value is NvxMatrixClearInput)
-            .ToDictionary(
-                kvp => kvp.Key,
-                kvp => kvp.Value);
+public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(kvp =>
+        kvp.Value is NvxMatrixClearInput
+        || kvp.Value is NvxMockMatrixInput
+        || (kvp.Value is NvxMatrixInput input && input.IsEnabled))
+    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
     public Dictionary<string, IRoutingOutputSlot> OutputSlots => _outputSlots.Where(
         kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
             .ToDictionary(

--- a/src/NvxEpi/Features/Routing/NvxMatrixClearInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixClearInput.cs
@@ -19,7 +19,9 @@ public class NvxMatrixClearInput : IRoutingInputSlot
 
     public string Key => "none";
 
+#pragma warning disable CS0067
     public event EventHandler VideoSyncChanged;
+#pragma warning restore CS0067
 
     public NvxMatrixClearInput()
     {

--- a/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
@@ -1,10 +1,10 @@
-﻿using NvxEpi.Abstractions.HdmiInput;
+﻿using System;
+using System.Linq;
+using NvxEpi.Abstractions.HdmiInput;
 using NvxEpi.Devices;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Routing;
-using System;
-using System.Linq;
 
 namespace NvxEpi.Features.Routing;
 
@@ -12,10 +12,10 @@ public class NvxMatrixInput : IRoutingInputSlot
 {
     private readonly NvxBaseDevice _device;
 
-    public NvxMatrixInput(NvxBaseDevice device):base()
+    public NvxMatrixInput(NvxBaseDevice device) : base()
     {
         _device = device;
-        
+
         try
         {
             if (_device is not IHdmiInput hdmiInput)
@@ -40,12 +40,13 @@ public class NvxMatrixInput : IRoutingInputSlot
 
                 feedback.Value.OutputChange += (o, a) => VideoSyncChanged?.Invoke(this, new EventArgs());
             }
-        } catch (Exception ex)
+        }
+        catch (Exception ex)
         {
             Debug.LogMessage(ex, "Exception creating Matrix Input", device);
         }
-        
-    }        
+
+    }
 
     public string TxDeviceKey => _device.Key;
 
@@ -60,6 +61,8 @@ public class NvxMatrixInput : IRoutingInputSlot
     public bool VideoSyncDetected => _device is IHdmiInput inputDevice && inputDevice.SyncDetected.Any(fb => fb.Value.BoolValue);
 
     public string Key => $"{_device.Key}";
+
+    public bool IsEnabled => _device.IsEnabled;
 
     public event EventHandler VideoSyncChanged;
 }

--- a/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
@@ -1,16 +1,16 @@
-﻿using NvxEpi.Abstractions.Stream;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NvxEpi.Abstractions.Stream;
 using NvxEpi.Devices;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Routing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxMatrixOutput :IRoutingOutputSlot
-{       
+public class NvxMatrixOutput : IRoutingOutputSlot
+{
     private readonly NvxBaseDevice _device;
 
     public NvxMatrixOutput(NvxBaseDevice device)
@@ -22,9 +22,10 @@ public class NvxMatrixOutput :IRoutingOutputSlot
             _device.CurrentStreamId.OutputChange += OnPrimaryOutputChange;
 
             _device.CurrentSecondaryAudioStreamId.OutputChange += OnSecondaryAudioOutputChange;
-        } catch (Exception ex)
+        }
+        catch (Exception ex)
         {
-            Debug.LogMessage(ex, "Exception creating NvxMatrixOutput {ex}", this, ex.Message);                
+            Debug.LogMessage(ex, "Exception creating NvxMatrixOutput {ex}", this, ex.Message);
         }
     }
 
@@ -94,6 +95,8 @@ public class NvxMatrixOutput :IRoutingOutputSlot
     public string Name => _device.Name;
 
     public string Key => $"{_device.Key}";
+
+    public bool IsEnabled => _device.IsEnabled;
 
     public event EventHandler OutputSlotChanged;
 }

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -240,6 +240,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
                 continue;
             }
 
+            if (device.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping feedback subscription", device.Key);
+                continue;
+            }
+
             // getting current local device for this remote when it changes and setting the feedback match object for this input port to that value
 
             device.Hardware.UsbInput.UsbInputChange += (o, a) =>
@@ -298,6 +304,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Output Port: {portKey}", outputPort.Key);
             OutputPorts.Add(outputPort);
+
+            if (remoteDevice.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", remoteDevice.Key);
+                continue;
+            }
 
             remoteDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {
@@ -368,6 +380,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Input Port: {portKey}", inputPort.Key);
             InputPorts.Add(inputPort);
+
+            if (localDevice.Hardware.UsbInput == null)
+            {
+                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", localDevice.Key);
+                continue;
+            }
 
             localDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -242,7 +242,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (device.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping feedback subscription", device.Key);
                 continue;
             }
 
@@ -307,7 +306,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (remoteDevice.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", remoteDevice.Key);
                 continue;
             }
 
@@ -383,7 +381,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             if (localDevice.Hardware.UsbInput == null)
             {
-                this.LogError("Device {deviceKey} does not support USB - skipping event subscription", localDevice.Key);
                 continue;
             }
 

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -276,12 +276,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         // Remote devices in NVX world are the USB peripherals like keyboards or touchscreen
         var usbRemoteDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => usb.IsRemote);
+            .Where(usb => usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // Local devices in NVX world are the USB Hosts like a PC
         var usbLocalDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => !usb.IsRemote);
+            .Where(usb => !usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // A local device can have multiple remote devices, but a remote device can only have one local device.
         // remote devices will be treated as Outputs and local devices as Inputs to mimic traditional video routing behavior.

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -240,11 +240,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
                 continue;
             }
 
-            if (device.Hardware.UsbInput == null)
-            {
-                continue;
-            }
-
             // getting current local device for this remote when it changes and setting the feedback match object for this input port to that value
 
             device.Hardware.UsbInput.UsbInputChange += (o, a) =>
@@ -281,12 +276,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         // Remote devices in NVX world are the USB peripherals like keyboards or touchscreen
         var usbRemoteDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => usb.IsRemote);
+            .Where(usb => usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // Local devices in NVX world are the USB Hosts like a PC
         var usbLocalDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => !usb.IsRemote);
+            .Where(usb => !usb.IsRemote && usb.Hardware.UsbInput != null);
 
         // A local device can have multiple remote devices, but a remote device can only have one local device.
         // remote devices will be treated as Outputs and local devices as Inputs to mimic traditional video routing behavior.
@@ -303,11 +298,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Output Port: {portKey}", outputPort.Key);
             OutputPorts.Add(outputPort);
-
-            if (remoteDevice.Hardware.UsbInput == null)
-            {
-                continue;
-            }
 
             remoteDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {
@@ -378,11 +368,6 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
             this.LogDebug("Adding USB Input Port: {portKey}", inputPort.Key);
             InputPorts.Add(inputPort);
-
-            if (localDevice.Hardware.UsbInput == null)
-            {
-                continue;
-            }
 
             localDevice.Hardware.UsbInput.UsbInputChange += (o, a) =>
             {

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -276,7 +276,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         // Remote devices in NVX world are the USB peripherals like keyboards or touchscreen
         var usbRemoteDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => usb.IsRemote && usb.Hardware.UsbInput != null);
+            .Where(usb => usb.IsRemote && usb.Hardware?.UsbInput != null);
 
         // Local devices in NVX world are the USB Hosts like a PC
         var usbLocalDevices = DeviceManager

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -281,7 +281,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         // Local devices in NVX world are the USB Hosts like a PC
         var usbLocalDevices = DeviceManager
             .AllDevices.OfType<IUsbStreamWithHardware>()
-            .Where(usb => !usb.IsRemote && usb.Hardware.UsbInput != null);
+            .Where(usb => !usb.IsRemote && usb.Hardware?.UsbInput != null);
 
         // A local device can have multiple remote devices, but a remote device can only have one local device.
         // remote devices will be treated as Outputs and local devices as Inputs to mimic traditional video routing behavior.

--- a/src/NvxEpi/Features/Streams/Audio/SecondaryAudioStream.cs
+++ b/src/NvxEpi/Features/Streams/Audio/SecondaryAudioStream.cs
@@ -92,7 +92,7 @@ public class SecondaryAudioStream : ISecondaryAudioStreamWithHardware
 
     public StringFeedback SecondaryAudioAddress
     {
-        get 
+        get
         {
             return _secondaryAudioAddres;
         }
@@ -112,4 +112,8 @@ public class SecondaryAudioStream : ISecondaryAudioStreamWithHardware
     {
         get { return _device.Hardware; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/Streams/Usb/UsbStream.cs
+++ b/src/NvxEpi/Features/Streams/Usb/UsbStream.cs
@@ -351,4 +351,8 @@ public class UsbStream : IUsbStreamWithHardware
     {
         get { return _device.IsOnline; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/Streams/Video/VideoStream.cs
+++ b/src/NvxEpi/Features/Streams/Video/VideoStream.cs
@@ -99,4 +99,8 @@ public class VideoStream : IStreamWithHardware
     {
         get { return _multicastVideoAddress; }
     }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/Features/Usbc/Input/UsbcInputBase.cs
+++ b/src/NvxEpi/Features/Usbc/Input/UsbcInputBase.cs
@@ -111,4 +111,8 @@ public abstract class UsbcInputBase : IUsbcInput
     public ReadOnlyDictionary<uint, StringFeedback> HdrType { get { return new ReadOnlyDictionary<uint, StringFeedback>(_hdrType); } }
 
     public ReadOnlyDictionary<uint, StringFeedback> HdcpSupport { get { return new ReadOnlyDictionary<uint, StringFeedback>(_hdcpSupport); } }
+
+    public bool IsEnabled => _device.IsEnabled;
+
+    public BoolFeedback EnabledFeedback => _device.EnabledFeedback;
 }

--- a/src/NvxEpi/McMessengers/MatrixRouterMessenger.cs
+++ b/src/NvxEpi/McMessengers/MatrixRouterMessenger.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NvxEpi.Abstractions;
+using NvxEpi.Features.Routing;
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.AppServer.Messengers;
+using PepperDash.Essentials.Core;
+
+namespace NvxEpi.McMessengers;
+/*
+public class MatrixRouterMessenger : MessengerBase
+{
+    private readonly NvxGlobalRouter device;
+    public MatrixRouterMessenger(string key, string messagePath, NvxGlobalRouter device) : base(key, messagePath, device)
+    {
+        this.device = device;
+
+        foreach (var slot in device.InputSlots.Values)
+        {
+            if (slot is NvxMatrixInput inputSlot)
+            {
+                var tx = DeviceManager.GetDeviceForKey<INvxDevice>(inputSlot.TxDeviceKey);
+                tx.EnabledFeedback.OutputChange += (o, args) => SendUpdate();
+            }
+        }
+
+        foreach (var slot in device.OutputSlots.Values)
+        {
+            if (slot is NvxMatrixOutput outputSlot)
+            {
+                var rx = DeviceManager.GetDeviceForKey<INvxDevice>(outputSlot.RxDeviceKey);
+                rx.EnabledFeedback.OutputChange += (o, args) => SendUpdate();
+            }
+        }
+    }
+
+    public void SendUpdate()
+    {
+        var inputs = device.InputSlots.Where(kvp => kvp.Value is NvxMatrixInput input && input.IsEnabled)
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp => new RoutingInput(kvp.Value));
+
+        var outputs = device.OutputSlots.Where(kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp => new RoutingOutput(kvp.Value));
+
+        var message = new MatrixStateMessage
+        {
+            Inputs = inputs,
+            Outputs = outputs
+        };
+
+        this.LogInformation("Sending matrix state update message: {message} path {path}", message, MessagePath);
+
+        PostStatusMessage(JToken.FromObject(message));
+    }
+}*/

--- a/src/NvxEpi/NvxEpi.4Series.csproj
+++ b/src/NvxEpi/NvxEpi.4Series.csproj
@@ -33,7 +33,7 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.24.4">
+    <PackageReference Include="PepperDashEssentials" Version="2.28.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/NvxEpi/NvxEpi.4Series.csproj
+++ b/src/NvxEpi/NvxEpi.4Series.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>NvxEpi</RootNamespace>
     <Deterministic>false</Deterministic>
     <AssemblyTitle>NvxEpi</AssemblyTitle>
-    <Company>PepperDash Technologies</Company>
+    <Company>PepperDash Technology</Company>
     <Description>This software is a plugin designed to work as a part of PepperDash Essentials for Crestron control processors. This plugin allows for control Crestron NVX devices.</Description>
     <Copyright>Copyright 2026</Copyright>
     <Version>1.0.0-local</Version>

--- a/src/NvxEpi/Services/Bridge/NvxDeviceBridge.cs
+++ b/src/NvxEpi/Services/Bridge/NvxDeviceBridge.cs
@@ -51,6 +51,9 @@ public class NvxDeviceBridge : IBridgeAdvanced
             if (feedback.Key == Hdmi1SyncDetectedFeedback.Key)
                 joinNumber = joinMap.Hdmi1SyncDetected.JoinNumber;
 
+            if (feedback.Key == DmSyncDetectedFeedback.Key)
+                joinNumber = joinMap.Hdmi1SyncDetected.JoinNumber;
+
             if (feedback.Key == Hdmi2SyncDetectedFeedback.Key)
                 joinNumber = joinMap.Hdmi2SyncDetected.JoinNumber;
 

--- a/src/NvxEpi/Services/Feedback/DeviceModeFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/DeviceModeFeedback.cs
@@ -10,12 +10,12 @@ public class DeviceModeFeedback
     public static IntFeedback GetFeedback(DmNvxBaseClass device)
     {
         if (device is DmNvxD3x)
-            return new IntFeedback(Key, () => (int) eDeviceMode.Receiver);
+            return new IntFeedback(Key, () => (int)eDeviceMode.Receiver);
 
-        if (device is DmNvxE3x)
-            return new IntFeedback(Key, () => (int) eDeviceMode.Transmitter);
+        if (device is DmNvxE3x || device is DmNvxE20)
+            return new IntFeedback(Key, () => (int)eDeviceMode.Transmitter);
 
-        var feedback = new IntFeedback(Key, () => (int) device.Control.DeviceModeFeedback);
+        var feedback = new IntFeedback(Key, () => (int)device.Control.DeviceModeFeedback);
         device.BaseEvent += (@base, args) => feedback.FireUpdate();
 
         return feedback;

--- a/src/NvxEpi/Services/Feedback/DmCurrentResolutionFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/DmCurrentResolutionFeedback.cs
@@ -1,0 +1,24 @@
+using Crestron.SimplSharpPro.DM.Streaming;
+using PepperDash.Essentials.Core;
+
+namespace NvxEpi.Services.Feedback;
+
+public class DmCurrentResolutionFeedback
+{
+    public const string Key = "DmInCurrentResolution";
+
+    public static StringFeedback GetFeedback(DmNvxBaseClass device)
+    {
+        if (device is not DmNvxE760x)
+            return new StringFeedback(Key, () => string.Empty);
+
+        var feedback = new StringFeedback(Key, () =>
+            string.Format("{0}x{1}@{2}",
+                device.DmIn.VideoAttributes.HorizontalResolutionFeedback.UShortValue,
+                device.DmIn.VideoAttributes.VerticalResolutionFeedback.UShortValue,
+                device.DmIn.VideoAttributes.FramesPerSecondFeedback.UShortValue));
+
+        device.DmIn.VideoAttributes.AttributeChange += (stream, args) => feedback.FireUpdate();
+        return feedback;
+    }
+}

--- a/src/NvxEpi/Services/Feedback/StreamUrlFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/StreamUrlFeedback.cs
@@ -21,6 +21,10 @@ public class StreamUrlFeedback
         {
             (device as DmNvxE3x).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();
         }
+        else if (device is DmNvxE20)
+        {
+            (device as DmNvxE20).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();
+        }
         else if (device is DmNvxE760x)
         {
             (device as DmNvxE760x).SourceTransmit.StreamChange += (stream, args) => feedback.FireUpdate();

--- a/src/NvxEpi/Services/Utilities/DeviceDefaults.cs
+++ b/src/NvxEpi/Services/Utilities/DeviceDefaults.cs
@@ -9,7 +9,7 @@ public static class DeviceDefaults
 {
     public static void SetTxDefaults(this DmNvxBaseClass device, NvxDeviceProperties props)
     {
-        if (device is not DmNvxE3x)
+        if (device is not DmNvxE3x && device is not DmNvxE20)
         {
             device.Control.DeviceMode = eDeviceMode.Transmitter;
         }


### PR DESCRIPTION
This pull request introduces support for the DmNvxE20 device throughout the codebase, adds enable/disable logic to NVX devices, and performs some cleanup and refactoring. The most significant changes include the implementation of the `NvxE20` device class, updates to core abstractions and interfaces, and enhancements to device activation and feedback mechanisms.

**Support for DmNvxE20 device:**

* Added new `NvxE20` device class in `src/NvxEpi/Devices/NvxE20.cs`, implementing relevant interfaces and handling HDMI input, routing, and feedback for the E20 hardware.
* Created `INvxE20Hardware` and `INvxE20DeviceWithHardware` interfaces to abstract E20-specific hardware and device functionality. [[1]](diffhunk://#diff-913d60a0034e21964e474df65e38576b601fda987fa2fab947a63d878efe9a6fR1-R8) [[2]](diffhunk://#diff-bbde680f27a2e7fde9b1a4ef513776200f55c8285e722d3ad6cadd1464056676R1-R8)
* Updated extension methods in `VideoInputExtensions.cs` to recognize and correctly handle `DmNvxE20` hardware alongside existing device types. [[1]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL40-R40) [[2]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL50-R50) [[3]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL60-R60) [[4]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL70-R70) [[5]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL80-R80) [[6]](diffhunk://#diff-ea21b3039f730d7df8239027ee5b1560b90476c3d2e24c9185bebfd2db3c750dL90-R90)

**Enable/disable logic and feedback:**

* Added `IsEnabled` property and `EnabledFeedback` to `INvxDevice` and implemented these in `NvxBaseDevice` and `NvxMockDevice`, including logic to update enabled state based on network properties and device configuration. [[1]](diffhunk://#diff-e703856b62d961491dcc1f37bd144d36ed682d55d2a112087a7c904cc2cd140eL10-R11) [[2]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR95-R122) [[3]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR189-R230) [[4]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR528-R532) [[5]](diffhunk://#diff-a61ce567051318aabd4724967dbfdb9f1350ccbf88110f4aeb03f58aa958e24cR368-R372)
* Enhanced device activation to initialize and update enable state, and to provide feedback when the state changes. [[1]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR95-R122) [[2]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR189-R230)

**Device activation and initialization improvements:**

* Refactored `NvxBaseDevice` to move device message queueing to an `Initialize` method, ensuring proper device setup. [[1]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aL187-R244) [[2]](diffhunk://#diff-ce2e2378b4e94bf119cdef3f1a811501bfeec827d613bcd78c017c10c390478aR261-R265)
* Improved handling of device activation for transmitters and added logic for E20 and E30 hardware types in routing and setup.

**Cleanup and minor refactoring:**

* Removed unused or unnecessary USB-related code from `NvxD3X` and `NvxE3X` device classes. [[1]](diffhunk://#diff-69b1160c5913cab95edd52857811e0a9f583d82552e558e8b8811848edc24b26L10) [[2]](diffhunk://#diff-69b1160c5913cab95edd52857811e0a9f583d82552e558e8b8811848edc24b26L39) [[3]](diffhunk://#diff-69b1160c5913cab95edd52857811e0a9f583d82552e558e8b8811848edc24b26L136-L140) [[4]](diffhunk://#diff-7149fe2a485e3c204755c2176af52fa9d448ac40b210bb1e53fbe96e768a4219L10) [[5]](diffhunk://#diff-7149fe2a485e3c204755c2176af52fa9d448ac40b210bb1e53fbe96e768a4219L34) [[6]](diffhunk://#diff-7149fe2a485e3c204755c2176af52fa9d448ac40b210bb1e53fbe96e768a4219L114-L118)
* Fixed a minor typo in the `README.md` device key.

These changes collectively enhance the platform's support for the DmNvxE20 device and improve device state management and feedback mechanisms.