### PR TITLE
Add AutoInputRoutingEnable bridge join for Automatic Input Routing

### DIFF
--- a/src/NvxEpi/Extensions/VideoInputExtensions.cs
+++ b/src/NvxEpi/Extensions/VideoInputExtensions.cs
@@ -42,6 +42,7 @@ public static class VideoInputExtensions
             return;
         }
         device.LogDebug("Switching Video Input to : 'Hdmi1'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Hdmi1;
     }
 
@@ -52,6 +53,7 @@ public static class VideoInputExtensions
             return;
         }
         device.LogDebug("Switching Video Input to : 'Hdmi2'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Hdmi2;
     }
 
@@ -62,6 +64,7 @@ public static class VideoInputExtensions
             return;
         }
         device.LogDebug("Switching Video Input to : 'Usbc1'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Usbc1;
     }
 
@@ -72,6 +75,7 @@ public static class VideoInputExtensions
             return;
         }
         device.LogDebug("Switching Video Input to : 'Usbc2'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Usbc2;
     }
 
@@ -82,6 +86,7 @@ public static class VideoInputExtensions
             return;
         }
         device.LogDebug("Switching Video Input to : 'Disable'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Disable;
     }
 
@@ -93,12 +98,43 @@ public static class VideoInputExtensions
         }
 
         device.LogDebug("Switching Video Input to : 'Stream'");
+        device.Hardware.Control.DisableAutomaticInputRouting();
         device.Hardware.Control.VideoSource = eSfpVideoSourceTypes.Stream;
     }
 
     public static void SetVideoToAutomatic(this ICurrentVideoInput device)
     {
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
+        {
+            return;
+        }
+
         device.LogDebug("Switching Video Input to : 'Automatic'");
         device.Hardware.Control.EnableAutomaticInputRouting();
+    }
+
+    public static void SetAutomaticInputRouting(this ICurrentVideoInput device, bool pressed)
+    {
+        // bridge join is a press/release digital signal; act once per press and ignore the release
+        if (!pressed)
+        {
+            return;
+        }
+
+        if (device.Hardware is DmNvxE3x || device.Hardware is DmNvxE20 || device.Hardware is DmNvxD3x)
+        {
+            return;
+        }
+
+        if (device.Hardware.Control.EnableAutomaticInputRoutingFeedback.BoolValue)
+        {
+            device.LogDebug("Disabling Automatic Input Routing");
+            device.Hardware.Control.DisableAutomaticInputRouting();
+        }
+        else
+        {
+            device.LogDebug("Enabling Automatic Input Routing");
+            device.Hardware.Control.EnableAutomaticInputRouting();
+        }
     }
 }

--- a/src/NvxEpi/Features/InputSwitching/VideoInputSwitcher.cs
+++ b/src/NvxEpi/Features/InputSwitching/VideoInputSwitcher.cs
@@ -10,6 +10,7 @@ public class VideoInputSwitcher : ICurrentVideoInput
 {
     private readonly StringFeedback _currentVideoInput;
     private readonly IntFeedback _currentVideoInputValue;
+    private readonly BoolFeedback _automaticInputRoutingEnabled;
     private readonly INvxDeviceWithHardware _device;
 
     public VideoInputSwitcher(INvxDeviceWithHardware device)
@@ -18,9 +19,11 @@ public class VideoInputSwitcher : ICurrentVideoInput
 
         _currentVideoInput = VideoInputFeedback.GetFeedback(Hardware);
         _currentVideoInputValue = VideoInputValueFeedback.GetFeedback(Hardware);
+        _automaticInputRoutingEnabled = AutomaticInputRoutingEnabledFeedback.GetFeedback(Hardware);
 
         Feedbacks.Add(_currentVideoInput);
         Feedbacks.Add(_currentVideoInputValue);
+        Feedbacks.Add(_automaticInputRoutingEnabled);
     }
 
     public StringFeedback CurrentVideoInput
@@ -31,6 +34,11 @@ public class VideoInputSwitcher : ICurrentVideoInput
     public IntFeedback CurrentVideoInputValue
     {
         get { return _currentVideoInputValue; }
+    }
+
+    public BoolFeedback AutomaticInputRoutingEnabled
+    {
+        get { return _automaticInputRoutingEnabled; }
     }
 
     public int DeviceId

--- a/src/NvxEpi/JoinMaps/NvxDeviceJoinMap.cs
+++ b/src/NvxEpi/JoinMaps/NvxDeviceJoinMap.cs
@@ -291,6 +291,20 @@ public class NvxDeviceJoinMap : JoinMapBaseAdvanced
             Description = "Dante Input"
         });
 
+    [JoinName("AutoInputRoutingEnable")]
+    public JoinDataComplete AutoInputRoutingEnable = new(
+        new JoinData
+        {
+            JoinNumber = 10,
+            JoinSpan = 1
+        },
+        new JoinMetadata
+        {
+            JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+            JoinType = eJoinType.Digital,
+            Description = "Automatic Input Routing Enable / Feedback"
+        });
+
     [JoinName("SupportsNax")] public JoinDataComplete SupportsNax = new(
         new JoinData
             {

--- a/src/NvxEpi/Services/Bridge/NvxDeviceBridge.cs
+++ b/src/NvxEpi/Services/Bridge/NvxDeviceBridge.cs
@@ -93,6 +93,9 @@ public class NvxDeviceBridge : IBridgeAdvanced
             if (feedback.Key == VideoInputValueFeedback.Key)
                 joinNumber = joinMap.VideoInput.JoinNumber;
 
+            if (feedback.Key == AutomaticInputRoutingEnabledFeedback.Key)
+                joinNumber = joinMap.AutoInputRoutingEnable.JoinNumber;
+
             if (feedback.Key == AudioInputFeedback.Key)
                 joinNumber = joinMap.AudioInput.JoinNumber;
 
@@ -183,7 +186,10 @@ public class NvxDeviceBridge : IBridgeAdvanced
         LinkNetworkPorts(trilist, joinMap);
 
         if (_device is ICurrentVideoInput videoInput)
+        {
             trilist.SetUShortSigAction(joinMap.VideoInput.JoinNumber, videoInput.SetVideoInput);
+            trilist.SetBoolSigAction(joinMap.AutoInputRoutingEnable.JoinNumber, videoInput.SetAutomaticInputRouting);
+        }
 
         var audioInput = _device as ICurrentAudioInput;
         if (audioInput != null)

--- a/src/NvxEpi/Services/Feedback/AutomaticInputRoutingEnabledFeedback.cs
+++ b/src/NvxEpi/Services/Feedback/AutomaticInputRoutingEnabledFeedback.cs
@@ -1,0 +1,18 @@
+using Crestron.SimplSharpPro.DM.Streaming;
+using PepperDash.Essentials.Core;
+
+namespace NvxEpi.Services.Feedback;
+
+public class AutomaticInputRoutingEnabledFeedback
+{
+    public const string Key = "AutomaticInputRoutingEnabled";
+
+    public static BoolFeedback GetFeedback(DmNvxBaseClass device)
+    {
+        var feedback = new BoolFeedback(Key,
+            () => device.Control.EnableAutomaticInputRoutingFeedback.BoolValue);
+
+        device.BaseEvent += (@base, args) => feedback.FireUpdate();
+        return feedback;
+    }
+}


### PR DESCRIPTION
## Summary

Adds SIMPL bridge support for the NVX device's "Automatic Input Routing" feature (`DmNvxControl.EnableAutomaticInputRouting()` / `DisableAutomaticInputRouting()`), which was previously only controllable from the device's own web UI and had no bridge/join exposure. This applies to both **receivers (decoders)** and **transmitters (encoders)** with dual HDMI inputs — the underlying SDK property lives on the shared control object used by both roles, and the new join/feedback carries no transmitter/receiver restriction (aside from the existing per-model hardware guard described below).

## Changes

- **New:** `AutomaticInputRoutingEnabledFeedback` — a `BoolFeedback` that reads the hardware's live `EnableAutomaticInputRoutingFeedback` state and updates on the device's `BaseEvent`. Registered for every device (TX and RX alike) via `VideoInputSwitcher`.
- **New digital join (10, `ToFromSIMPL`):** `AutoInputRoutingEnable` in the join map — a single join used both to trigger the toggle and to report current state back to SIMPL.
- **`VideoInputExtensions.SetAutomaticInputRouting(bool)`:** wired to the new join. Only acts on the rising (press) edge and toggles the current hardware state, ignoring the release edge. This avoids a double-fire bug where a single momentary press (as sent by some digital join test tools) would enable then immediately disable the feature, since the underlying `SetBoolSigAction` helper forwards both transitions of the signal.
- **`SetVideoToAutomatic()` (legacy analog `VideoInput = 4` path):** kept as a separate, idempotent explicit "enable" call (not a toggle) and given a hardware-support guard it was previously missing.
- **Bug fix:** the other explicit `VideoInput` values (1, 2, 3, 11, 12, 99) previously never disabled automatic routing when switching to an explicit source, so the hardware's auto-routing state (and now its bridge feedback) could stay stuck "enabled" after an explicit input selection. All of them now call `DisableAutomaticInputRouting()` before setting their source.
- `VideoInputSwitcher` registers the new feedback; `NvxDeviceBridge` routes the feedback to its join and wires the new `SetBoolSigAction`.

## Scope: encoders and decoders

- `VideoInputSwitcher` (and therefore this feature) is constructed unconditionally for every device in `NvxBaseDevice`, regardless of transmitter/receiver role.
- None of the new/changed methods add an `IsTransmitter` exclusion. The only role-specific exclusion in this file remains `SetVideoToStream()`, which excludes transmitters because "Stream" as a video source is meaningless for a device that produces a stream rather than consumes one — that exclusion is unrelated to this change and was already in place.
- On dual-HDMI-input models capable of running in encoder mode, enabling Automatic Input Routing lets the device auto-select between its own HDMI1/HDMI2 inputs for what it streams, using the same SDK mechanism a receiver uses to auto-select its active source.

## Compatibility

`EnableAutomaticInputRouting()` / `DisableAutomaticInputRouting()` are not supported on all NVX hardware variants (single-HDMI-input models); all new/changed code paths early-return (no-op) on those models, consistent with the existing guard pattern used elsewhere in this file. This guard is based on hardware model only, not on encoder/decoder role.

## Testing

- `dotnet build` succeeds with 0 errors.
- Verified on physical hardware: bridge-driven join now produces exactly one enable/disable action per press, matching the device web UI's existing one-press-one-action behavior.