### PR TITLE
feat!: migrate to Essentials v3 / net8 (incl. routing-interface overhaul)

### DIFF
--- a/_Context/v3-migration-plan.md
+++ b/_Context/v3-migration-plan.md
@@ -1,0 +1,89 @@
+# v3 Migration Plan — epi-crestron-nvx
+
+> Generated 2026-08-13 by essentials-epi agent (read-only `scan-plugin-v3-readiness.ps1`, Mode V3). Re-run the scan before starting work in case the repo has drifted since this was written.
+> Work happens on branch `feature/v3-migration`.
+
+## Program Context
+
+This repo is 1 of 5 EPIs being converted to Essentials v3 in this effort:
+`epi-videoCodec-ciscoExtended`, `epi-cisco-cli`, `epi-crestron-nvx`, `epi-epson-projector`, `epi-netgear-cli`.
+`epi-videoCodec-ciscoExtended` is on hold until its in-progress feature branches are merged to `main` — do not start that one from this plan set.
+**Do this repo last** — largest and most complex of the 5.
+
+## Current State
+
+| | |
+|---|---|
+| Target framework | `net472` |
+| Essentials version | `2.28.0` |
+| `SERIES4` define | present |
+| C# files | 204 (largest of the 5) |
+| `#if SERIES4` conditionals | 0 |
+| Removed .NET APIs | **24 hits** — see breakdown below |
+| Factories | 3 — `NvxApplicationFactory`, `NvxDirectorFactory` (both `minVersion: null` — never set), plus `NvxBaseDeviceFactory.cs` (base class, no `className`/`minVersion`/`typeNames` of its own — verify it doesn't need one) |
+| 3-Series artifacts | none detected |
+| Debug.Console remaining | 0 (404 calls already migrated to Serilog) |
+
+## Risk: **High**
+
+Largest file count by far, and — beyond the base v2→v3 mechanics — this repo **also needs the routing-interface migration** (confirmed below), not just the v2→v3 base workflow.
+
+## ⚠️ Confirmed: Needs BOTH migrations
+
+1. **Base v2→v3** (`migrate-v2-to-v3`) — csproj/net8, factory version bumps, logging already done.
+2. **Routing-interface overhaul** (`migrate-plugin-routing-v3`) — confirmed via grep: this repo implements the **removed** interface family:
+   - `NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting` (`Features\Routing\NvxGlobalRouter.cs`)
+   - `IRoutingInputSlot` implemented/used in `NvxMatrixClearInput.cs`, `NvxMatrixInput.cs`, `NvxMatrixOutput.cs`, `NvxMockMatrixInput.cs`, and stored in `Dictionary<string, IRoutingInputSlot>` collections in `NvxGlobalRouter.cs`
+
+   Per [`context/routing-v3-migration.md`](../../../context/routing-v3-migration.md):
+   - `IRoutingNumeric` / `IMatrixRouting` → **`IRoutingMidpointWithFeedback`**
+   - `IRoutingInputSlot` → **no core equivalent** — since nothing outside this plugin appears to consume it, use the **plugin-local slot pattern** (a plugin-local `INvxInputSlot : IKeyName` interface carrying only the members actually used — see the skill for the template).
+   - Reference the **epi-wyrestorm-networkHD PR #3** worked example in that doc — same shape (`IRoutingNumeric, IMatrixRouting` → `IRoutingMidpointWithFeedback`, plugin-local input slot).
+   - This is a **design/architecture task**, not mechanical — budget real review time, and land as a **draft PR pending hardware/bench validation** (routing behavior isn't covered by validation test suites — see "Validation reality" in the routing doc).
+
+## Removed .NET API Breakdown (24 hits — all mechanical, no design-discussion blockers)
+
+| Pattern | Count | Fix |
+|---|---|---|
+| `eRoutingSignalType.SecondaryAudio` | ~14 | Replace with `eRoutingSignalType.AudioVideo` |
+| `eRoutingSignalType.UsbInput` / `UsbOutput` | ~8 | Replace with `eRoutingSignalType.Usb` (⚠️ check for `UsbInput \| UsbOutput` combinations collapsing to `Usb \| Usb` — dedupe) |
+| `Crestron.SimplSharp.Reflection` | 2 (`Enumeration.cs`, `AssemblyInfo.cs`) | `using System.Reflection;` |
+| `.GetCType()` | 2 (`Enumeration.cs`) | Replace with `.GetType()` |
+
+Files affected (from scan): `NvxMockDevice.cs`, `Enumeration.cs`, `NvxGlobalRouter.cs`, `NvxMatrixInput.cs`, `NvxMatrixOutput.cs`, `NvxMockMatrixInput.cs`, `PrimaryStreamRouter.cs`, `SecondaryAudioRouter.cs`, `UsbRouter.cs`, `AssemblyInfo.cs`, `InputPorts\SecondaryAudioInput.cs`, `InputSwitching\SwitcherForAnalogAudioOutput.cs`, `InputSwitching\SwitcherForSecondaryAudioOutput.cs`, `TieLines\TieLineConnector.cs`. None are "design-discussion" categories (no `BinaryFormatter`/`AppDomain.CreateDomain`/`Thread.Abort`/`System.Web`), so these don't block starting — but do them **before** the routing-interface work, since the interface migration touches the same routing files anyway.
+
+## Skills to Use (in order)
+
+1. [`sub-agents/essentials-epi/skills/migrate-v2-to-v3/SKILL.md`](../../../skills/migrate-v2-to-v3/SKILL.md) — Phases 1-2 (csproj, factory), then the removed-API fixes above as part of Phase 3
+2. [`sub-agents/essentials-epi/skills/migrate-plugin-routing-v3/SKILL.md`](../../../skills/migrate-plugin-routing-v3/SKILL.md) — routing-interface overhaul
+3. [`context/routing-v3-migration.md`](../../../context/routing-v3-migration.md) — reference doctrine for step 2
+
+## Pre-Flight (do first, every session — per essentials-epi's mandatory git pre-flight rule)
+
+1. `git fetch`, confirm branch is `feature/v3-migration`, confirm 0 behind upstream, confirm clean working tree.
+2. Confirm this branch is still correctly based on an up-to-date `main`. Note this repo also had an in-progress feature branch (`feature/add-usb-audiovideo-switching`) at plan time — confirm with the user whether that work needs to land first, same concern as the codec repo.
+
+## Task Checklist
+
+- [ ] Re-run `analyze-plugin` scan to confirm nothing changed since this plan was written
+- [ ] **Ask user**: does `feature/add-usb-audiovideo-switching` (or any other in-progress branch) need to merge to `main` before this migration starts? (Same pattern as the codec repo hold.)
+- [ ] Phase 2a: `<TargetFramework>net472</TargetFramework>` → `net8` in `src\NvxEpi\NvxEpi.4Series.csproj`
+- [ ] Phase 2a: remove both `SERIES4` `DefineConstants` `PropertyGroup` blocks
+- [ ] Phase 2a: bump `PepperDashEssentials` PackageReference to `3.0.0`
+- [ ] Phase 2b: set `MinimumEssentialsFrameworkVersion = "3.0.0"` on `NvxApplicationFactory` and `NvxDirectorFactory` (currently unset — not just outdated)
+- [ ] Phase 2b: check `NvxBaseDeviceFactory.cs` — confirm whether it needs its own `MinimumEssentialsFrameworkVersion`/`TypeNames` or is purely a base class
+- [ ] Phase 3: fix all 24 removed-API hits (table above) — `SecondaryAudio`→`AudioVideo`, `UsbInput`/`UsbOutput`→`Usb` (watch for redundant flag combos), `Crestron.SimplSharp.Reflection`→`System.Reflection`, `.GetCType()`→`.GetType()`
+- [ ] Phase 3c: check `Initialize()`/`CustomActivate()` visibility and external callers (large device surface — check all device classes, not just one)
+- [ ] **Routing migration**: convert `NvxGlobalRouter` (`IRoutingNumeric, IMatrixRouting`) to `IRoutingMidpointWithFeedback`; implement `ExecuteSwitch`/`ClearRoute`/`CurrentRoutes`/`RouteChanged`
+- [ ] **Routing migration**: design + implement plugin-local `INvxInputSlot` (or similar) to replace `IRoutingInputSlot` across `NvxMatrixClearInput.cs`, `NvxMatrixInput.cs`, `NvxMatrixOutput.cs`, `NvxMockMatrixInput.cs`
+- [ ] Phase 4: verify join maps — all fields `public`, `base(joinStart, typeof(...))`, `[JoinName]` attributes match
+- [ ] Phase 5: `dotnet restore` + `dotnet build` on `NvxEpi.4Series.sln`, fix any compile errors
+- [ ] Update README's "Minimum Essentials Framework Versions" section if present
+- [ ] Commit with `feat!:` / `BREAKING CHANGE:` footer (major version bump)
+- [ ] Verify `output/` `.cplz` builds
+- [ ] **Land as draft PR** pending hardware/bench validation of routing behavior (build-clean ≠ routing-works, per routing doc's "Validation reality" section)
+
+## Notes / Flags
+
+- This is the highest-effort repo of the 5 — budget accordingly, and treat the routing-interface conversion as a design task requiring review, not a mechanical find/replace.
+- Confirm with user whether the in-progress `feature/add-usb-audiovideo-switching` branch needs merging first (same open question as the codec repo).

--- a/epi-crestron-nvx.4Series.sln
+++ b/epi-crestron-nvx.4Series.sln
@@ -5,19 +5,55 @@ VisualStudioVersion = 17.8.34601.278
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "epi-crestron-nvx.4Series", "src\NvxEpi\epi-crestron-nvx.4Series.csproj", "{A24B641A-8D55-412B-8522-C2F825B17BF9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "epi-crestron-nvx.Tests", "tests\epi-crestron-nvx.Tests.csproj", "{7F317274-29C3-494A-867F-52F3DF2AD17C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NvxEpi", "NvxEpi", "{45E88A65-67D3-E886-34F0-3E802544ED1D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|x64.Build.0 = Debug|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Debug|x86.Build.0 = Debug|Any CPU
 		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|x64.ActiveCfg = Release|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|x64.Build.0 = Release|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|x86.ActiveCfg = Release|Any CPU
+		{A24B641A-8D55-412B-8522-C2F825B17BF9}.Release|x86.Build.0 = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|x64.Build.0 = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F317274-29C3-494A-867F-52F3DF2AD17C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7F317274-29C3-494A-867F-52F3DF2AD17C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{45E88A65-67D3-E886-34F0-3E802544ED1D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DA074D94-0A55-463E-8A97-3E45A81AD79A}

--- a/epi-crestron-nvx.4Series.sln
+++ b/epi-crestron-nvx.4Series.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34601.278
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NvxEpi.4Series", "src\NvxEpi\NvxEpi.4Series.csproj", "{A24B641A-8D55-412B-8522-C2F825B17BF9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "epi-crestron-nvx.4Series", "src\NvxEpi\epi-crestron-nvx.4Series.csproj", "{A24B641A-8D55-412B-8522-C2F825B17BF9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NvxEpi/Abstractions/INvxDevice.cs
+++ b/src/NvxEpi/Abstractions/INvxDevice.cs
@@ -4,7 +4,7 @@ using PepperDash.Essentials.Core;
 
 namespace NvxEpi.Abstractions;
 
-public interface INvxDevice : IRoutingInputsOutputs,
+public interface INvxDevice : IRoutingMidpoint,
     IHasFeedback, IOnline, ITransmitterReceiver, IKeyName, IDeviceId
 {
     bool IsEnabled { get; }

--- a/src/NvxEpi/Application/Entities/NvxApplicationAudioReceiver.cs
+++ b/src/NvxEpi/Application/Entities/NvxApplicationAudioReceiver.cs
@@ -18,7 +18,7 @@ public class NvxApplicationAudioReceiver : EssentialsDevice
     private readonly IEnumerable<NvxApplicationAudioTransmitter> _transmitters;
     public int DeviceId { get; private set; }
     public INvxDeviceWithHardware Device { get; private set; }
-    public IRoutingSink Amp { get; private set; }
+    public IRoutingInputs Amp { get; private set; }
     public StringFeedback AudioName { get; private set; }
     public StringFeedback CurrentAudioRouteName { get; private set; }
     public IntFeedback CurrentAudioRouteId { get; private set; }

--- a/src/NvxEpi/Application/Entities/NvxApplicationVideoReceiver.cs
+++ b/src/NvxEpi/Application/Entities/NvxApplicationVideoReceiver.cs
@@ -17,7 +17,7 @@ public class NvxApplicationVideoReceiver : EssentialsDevice, IOnline
     private readonly IEnumerable<NvxApplicationVideoTransmitter> _transmitters;
     public int DeviceId { get; private set; }
     public INvxDevice Device { get; private set; }
-    public IRoutingSink Display { get; private set; }
+    public IRoutingInputs Display { get; private set; }
     public StringFeedback NameFeedback { get; private set; }
     public StringFeedback VideoName { get; private set; }
     public StringFeedback CurrentVideoRouteName { get; private set; }

--- a/src/NvxEpi/Application/Services/Amplifier.cs
+++ b/src/NvxEpi/Application/Services/Amplifier.cs
@@ -6,32 +6,8 @@ using PepperDash.Essentials.Core.Config;
 
 namespace PepperDash.Essentials;
 
-public class Amplifier : EssentialsDevice, IRoutingSink
+public class Amplifier : EssentialsDevice, IRoutingInputs
 {
-    public event SourceInfoChangeHandler CurrentSourceChange;
-
-    public string CurrentSourceInfoKey { get; set; }
-    public SourceListItem CurrentSourceInfo
-    {
-        get
-        {
-            return _CurrentSourceInfo;
-        }
-        set
-        {
-            if (value == _CurrentSourceInfo) return;
-
-            var handler = CurrentSourceChange;
-
-            handler?.Invoke(_CurrentSourceInfo, ChangeType.WillChange);
-
-            _CurrentSourceInfo = value;
-
-            handler?.Invoke(_CurrentSourceInfo, ChangeType.DidChange);
-        }
-    }
-    SourceListItem _CurrentSourceInfo;
-
     public RoutingInputPort CurrentInputPort => AudioIn;
 
     public RoutingInputPort AudioIn { get; private set; }

--- a/src/NvxEpi/Devices/Nvx35x.cs
+++ b/src/NvxEpi/Devices/Nvx35x.cs
@@ -52,7 +52,7 @@ public class Nvx35X :
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         var hardware = base.Hardware as DmNvx35x ?? throw new Exception("hardware built doesn't match");
         Hardware = hardware;

--- a/src/NvxEpi/Devices/Nvx35x.cs
+++ b/src/NvxEpi/Devices/Nvx35x.cs
@@ -34,7 +34,7 @@ public class Nvx35X :
     IUsbStreamWithHardware,
     IHdmiInput,
     IVideowallMode,
-    IRoutingWithFeedback,
+    IRoutingMidpointWithFeedback,
     ICec,
     INvx35XDeviceWithHardware
 {
@@ -223,6 +223,10 @@ public class Nvx35X :
             this.LogDebug(ex, "Stack Trace: ");
         }
     }
+
+    // NvxGlobalRouter/NvxMatrixOutput already own the matrix-layer clear operation -
+    // no per-device clear semantics exist below that layer today.
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
     {

--- a/src/NvxEpi/Devices/Nvx36X.cs
+++ b/src/NvxEpi/Devices/Nvx36X.cs
@@ -52,7 +52,7 @@ public class Nvx36X
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         try
         {

--- a/src/NvxEpi/Devices/Nvx36X.cs
+++ b/src/NvxEpi/Devices/Nvx36X.cs
@@ -33,7 +33,7 @@ public class Nvx36X
         IUsbStreamWithHardware,
         IHdmiInput,
         IVideowallMode,
-        IRoutingWithFeedback,
+        IRoutingMidpointWithFeedback,
         ICec,
         IBasicVolumeWithFeedback
 {
@@ -264,6 +264,8 @@ public class Nvx36X
             this.LogDebug(ex, "Stack Trace: ");
         }
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(
         BasicTriList trilist,

--- a/src/NvxEpi/Devices/Nvx38X.cs
+++ b/src/NvxEpi/Devices/Nvx38X.cs
@@ -57,7 +57,7 @@ public class Nvx38X
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         try
         {

--- a/src/NvxEpi/Devices/Nvx38X.cs
+++ b/src/NvxEpi/Devices/Nvx38X.cs
@@ -37,7 +37,7 @@ public class Nvx38X
         IUsbcInput,
         IVideowallMode,
         IMultiview,
-        IRoutingWithFeedback,
+        IRoutingMidpointWithFeedback,
         ICec,
         IBasicVolumeWithFeedback
 {
@@ -406,6 +406,8 @@ public class Nvx38X
             this.LogDebug(ex, "Stack Trace: ");
         }
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(
         BasicTriList trilist,

--- a/src/NvxEpi/Devices/NvxBaseDevice.cs
+++ b/src/NvxEpi/Devices/NvxBaseDevice.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Timers;
 using Crestron.SimplSharp;
 using Crestron.SimplSharpPro;
-using Crestron.SimplSharpPro.CrestronThread;
 using Crestron.SimplSharpPro.DM.Streaming;
 using NvxEpi.Abstractions.HdmiInput;
 using NvxEpi.Abstractions.HdmiOutput;
@@ -62,7 +62,7 @@ public abstract class NvxBaseDevice
 
     private static IQueue<IQueueMessage> _queue;
 
-    private Timer debounceTimer;
+    private System.Timers.Timer debounceTimer;
 
     static NvxBaseDevice()
     {
@@ -86,7 +86,7 @@ public abstract class NvxBaseDevice
 
         _queue ??= new GenericQueue(
             "NvxDeviceBuildQueue",
-            Thread.eThreadPriority.LowestPriority,
+            ThreadPriority.Lowest,
             200
         );
 
@@ -137,7 +137,7 @@ public abstract class NvxBaseDevice
         AddPreActivationAction(() => RegisterForOnlineFeedback(Hardware, props));
         AddPostActivationAction(() => RegisterForNetworkChangeFeedback());
 
-        debounceTimer = new Timer(30000) { Enabled = false, AutoReset = false };
+        debounceTimer = new System.Timers.Timer(30000) { Enabled = false, AutoReset = false };
 
         debounceTimer.Elapsed += (sender, args) =>
         {
@@ -180,7 +180,7 @@ public abstract class NvxBaseDevice
         _hardwareName = r.Replace(tempName, "");
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         try
         {
@@ -258,7 +258,7 @@ public abstract class NvxBaseDevice
         }
     }
 
-    public override void Initialize()
+    protected override void Initialize()
     {
         _queue.Enqueue(new BuildNvxDeviceMessage(Key, Hardware));
     }

--- a/src/NvxEpi/Devices/NvxD3X.cs
+++ b/src/NvxEpi/Devices/NvxD3X.cs
@@ -44,7 +44,7 @@ public class NvxD3X :
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         var hardware = base.Hardware as DmNvxD3x ?? throw new Exception("hardware built doesn't match");
         Hardware = hardware;

--- a/src/NvxEpi/Devices/NvxD3X.cs
+++ b/src/NvxEpi/Devices/NvxD3X.cs
@@ -29,7 +29,7 @@ public class NvxD3X :
     IComPorts,
     IIROutputPorts,
     IHdmiOutput,
-    IRoutingWithFeedback,
+    IRoutingMidpointWithFeedback,
     ICec,
     IBasicVolumeWithFeedback
 {
@@ -168,6 +168,8 @@ public class NvxD3X :
             Debug.LogMessage(ex, "Error executing switch!", this);
         }
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
     {

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -37,7 +37,7 @@ public class NvxE20 :
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         try
         {

--- a/src/NvxEpi/Devices/NvxE20.cs
+++ b/src/NvxEpi/Devices/NvxE20.cs
@@ -25,7 +25,7 @@ public class NvxE20 :
     NvxBaseDevice,
     INvxE20DeviceWithHardware,
     IHdmiInput,
-    IRoutingWithFeedback
+    IRoutingMidpointWithFeedback
 {
     private IHdmiInput _hdmiInputs;
 
@@ -161,6 +161,8 @@ public class NvxE20 :
             this.LogVerbose(ex.Message);
         }
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
     {

--- a/src/NvxEpi/Devices/NvxE3X.cs
+++ b/src/NvxEpi/Devices/NvxE3X.cs
@@ -27,7 +27,7 @@ public class NvxE3X :
     IComPorts,
     IIROutputPorts,
     IHdmiInput,
-    IRoutingWithFeedback
+    IRoutingMidpointWithFeedback
 {
     private IHdmiInput _hdmiInputs;
 
@@ -192,6 +192,8 @@ public class NvxE3X :
             Debug.LogMessage(ex, "Error executing switch!", this);
         }
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
 
     public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
     {

--- a/src/NvxEpi/Devices/NvxE3X.cs
+++ b/src/NvxEpi/Devices/NvxE3X.cs
@@ -39,7 +39,7 @@ public class NvxE3X :
         AddPreActivationAction(AddRoutingPorts);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         try
         {

--- a/src/NvxEpi/Devices/NvxMockDevice.cs
+++ b/src/NvxEpi/Devices/NvxMockDevice.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM.Streaming;
@@ -26,7 +27,7 @@ public class NvxMockDevice
     : ReconfigurableDevice,
         IStream,
         ISecondaryAudioStream,
-        IRoutingNumeric,
+        IRoutingMidpointWithFeedback,
         IBridgeAdvanced,
         IHasFeedback
 {
@@ -278,6 +279,12 @@ public class NvxMockDevice
     {
         this.LogVerbose("Executing switch : {0}", signalType);
     }
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType) { }
+
+    public List<RouteSwitchDescriptor> CurrentRoutes { get; } = new();
+
+    public event RouteChangedEventHandler RouteChanged { add { } remove { } }
 
     public void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type)
     {

--- a/src/NvxEpi/Devices/NvxMockDevice.cs
+++ b/src/NvxEpi/Devices/NvxMockDevice.cs
@@ -180,7 +180,7 @@ public class NvxMockDevice
         InputPorts.Add(
             new RoutingInputPort(
                 DeviceInputEnum.SecondaryAudio.Name,
-                eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
+                eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo,
                 eRoutingPortConnectionType.Streaming,
                 DeviceInputEnum.SecondaryAudio,
                 this
@@ -190,7 +190,7 @@ public class NvxMockDevice
         OutputPorts.Add(
             new RoutingOutputPort(
                 SwitcherForSecondaryAudioOutput.Key,
-                eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
+                eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo,
                 eRoutingPortConnectionType.LineAudio,
                 null,
                 this
@@ -236,7 +236,7 @@ public class NvxMockDevice
         }
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         Feedbacks.ToList().ForEach(x => x.FireUpdate());
 

--- a/src/NvxEpi/Devices/NvxXioDirector.cs
+++ b/src/NvxEpi/Devices/NvxXioDirector.cs
@@ -39,7 +39,7 @@ public class NvxXioDirector : EssentialsDevice, INvxDirector, IOnline, ICommunic
         AddPreActivationAction(() => CommunicationMonitor = new NvxCommunicationMonitor(this, 10000, 30000, _hardware));
     }
 
-    public override void Initialize()
+    protected override void Initialize()
     {
         this.LogDebug("Director configured with {count} domains out of {max}", _hardware.Domain.Count, _hardware.MaximumNumberOfDomains);
 
@@ -55,7 +55,7 @@ public class NvxXioDirector : EssentialsDevice, INvxDirector, IOnline, ICommunic
         _hardware.RegisterWithLogging(Key);
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         CommunicationMonitor.Start();
 

--- a/src/NvxEpi/Enums/Enumeration.cs
+++ b/src/NvxEpi/Enums/Enumeration.cs
@@ -73,10 +73,10 @@ public abstract class Enumeration<TEnum> : IComparable<Enumeration<TEnum>> where
             var a = baseType.Assembly;
 
             Debug.LogVerbose("Base type: {0}", baseType.Name);
-            IEnumerable<CType> enumTypes = a.GetTypes().Where(baseType.IsAssignableFrom);
+            IEnumerable<Type> enumTypes = a.GetTypes().Where(baseType.IsAssignableFrom);
 
             var options = new List<TEnum>();
-            foreach (CType enumType in enumTypes)
+            foreach (Type enumType in enumTypes)
             {
                 Debug.LogVerbose("Found enum type: {0}", enumType.Name);
                 var fields =

--- a/src/NvxEpi/Enums/Enumeration.cs
+++ b/src/NvxEpi/Enums/Enumeration.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Crestron.SimplSharp;
-using Crestron.SimplSharp.Reflection;
+using System.Reflection;
 using PepperDash.Core;
 
 namespace NvxEpi.Enums;
@@ -44,7 +44,7 @@ public abstract class Enumeration<TEnum> : IComparable<Enumeration<TEnum>> where
         if (obj is not Enumeration<TEnum> otherValue)
             return false;
 
-        bool typeMatches = GetType().GetCType() == obj.GetType().GetCType();
+        bool typeMatches = GetType() == obj.GetType();
         bool valueMatches = Value.Equals(otherValue.Value);
 
         return typeMatches && valueMatches;
@@ -69,7 +69,7 @@ public abstract class Enumeration<TEnum> : IComparable<Enumeration<TEnum>> where
     {
         try
         {
-            var baseType = typeof(TEnum).GetCType();
+            var baseType = typeof(TEnum);
             var a = baseType.Assembly;
 
             Debug.LogVerbose("Base type: {0}", baseType.Name);

--- a/src/NvxEpi/Extensions/RoutingFeedbackExtensions.cs
+++ b/src/NvxEpi/Extensions/RoutingFeedbackExtensions.cs
@@ -8,9 +8,10 @@ using PepperDash.Essentials.Core;
 using System.Linq;
 
 namespace NvxEpi.Extensions;
+
 public static class RoutingFeedbackExtensions
 {
-    public static RouteSwitchDescriptor HandleBaseEvent(this IRoutingWithFeedback parent, BaseEventArgs args)
+    public static RouteSwitchDescriptor HandleBaseEvent(this IRoutingMidpointWithFeedback parent, BaseEventArgs args)
     {
         if (parent is not NvxBaseDevice parentBase)
         {
@@ -69,8 +70,8 @@ public static class RoutingFeedbackExtensions
 
                         return newRouteDescriptor;
                     }
-                    
-                    if(currentInputPort == null)
+
+                    if (currentInputPort == null)
                     {
                         parent.CurrentRoutes.Remove(existingRouteDescriptor);
                         return null;
@@ -78,7 +79,7 @@ public static class RoutingFeedbackExtensions
 
                     existingRouteDescriptor.InputPort = currentInputPort;
 
-                    return existingRouteDescriptor;                    
+                    return existingRouteDescriptor;
                 }
             case DMInputEventIds.DmNaxAudioSourceFeedbackEventId: //Analog/HDMI Output Audio source
                 {
@@ -170,6 +171,6 @@ public static class RoutingFeedbackExtensions
                 }
             default:
                 return null;
-        }        
+        }
     }
 }

--- a/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
+++ b/src/NvxEpi/Factories/NvxBaseDeviceFactory.cs
@@ -12,7 +12,7 @@ namespace NvxEpi.Factories;
 
 public abstract class NvxBaseDeviceFactory<T> : EssentialsPluginDeviceFactory<T> where T : EssentialsDevice
 {
-    public const string MinumumEssentialsVersion = "2.28.0";
+    public const string MinumumEssentialsVersion = "3.0.0-dev-v3-routing.63";
 
     static NvxBaseDeviceFactory()
     {

--- a/src/NvxEpi/Factories/NvxDirectorFactory.cs
+++ b/src/NvxEpi/Factories/NvxDirectorFactory.cs
@@ -13,6 +13,8 @@ public class NvxDirectorFactory : EssentialsPluginDeviceFactory<NvxXioDirector>
 {
     public NvxDirectorFactory()
     {
+        MinimumEssentialsFrameworkVersion = NvxBaseDeviceFactory<NvxXioDirector>.MinumumEssentialsVersion;
+
         TypeNames = new List<string>
             {
                 "xiodirector",

--- a/src/NvxEpi/Features/Routing/INvxRoutingSlots.cs
+++ b/src/NvxEpi/Features/Routing/INvxRoutingSlots.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using PepperDash.Core;
+using PepperDash.Essentials.Core;
+
+namespace NvxEpi.Features.Routing;
+
+// Plugin-local replacement for the removed core IRoutingInputSlot/IRoutingOutputSlot -
+// the slot abstraction was removed in the v3 routing overhaul with no core equivalent,
+// and nothing outside this plugin consumed the old interfaces, so this carries only the
+// members actually used by NvxGlobalRouter and its slot implementations.
+public interface INvxInputSlot : IKeyName
+{
+    string TxDeviceKey { get; }
+    int SlotNumber { get; }
+    eRoutingSignalType SupportedSignalTypes { get; }
+    BoolFeedback IsOnline { get; }
+    bool VideoSyncDetected { get; }
+    event EventHandler VideoSyncChanged;
+}
+
+public interface INvxOutputSlot : IKeyName
+{
+    string RxDeviceKey { get; }
+    int SlotNumber { get; }
+    eRoutingSignalType SupportedSignalTypes { get; }
+    Dictionary<eRoutingSignalType, INvxInputSlot> CurrentRoutes { get; }
+    event EventHandler OutputSlotChanged;
+}

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -98,14 +98,11 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
         if (
             signalType.Has(eRoutingSignalType.Audio)
-            || signalType.Has(eRoutingSignalType.SecondaryAudio)
+            || signalType.Has(eRoutingSignalType.AudioVideo)
         )
             SecondaryAudioRouter.ExecuteSwitch(inputSelector, outputSelector, signalType);
 
-        if (
-            signalType.HasFlag(eRoutingSignalType.UsbInput)
-            || signalType.HasFlag(eRoutingSignalType.UsbOutput)
-        )
+        if (signalType.HasFlag(eRoutingSignalType.Usb))
             UsbRouter.ExecuteSwitch(inputSelector, outputSelector, signalType);
     }
 
@@ -116,11 +113,16 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
     private Dictionary<string, IRoutingInputSlot> _inputSlots = new();
     private Dictionary<string, IRoutingOutputSlot> _outputSlots = new();
-public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(kvp =>
-        kvp.Value is NvxMatrixClearInput
-        || kvp.Value is NvxMockMatrixInput
-        || (kvp.Value is NvxMatrixInput input && input.IsEnabled))
-    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(kvp =>
+
+            kvp.Value is NvxMatrixClearInput
+
+            || kvp.Value is NvxMockMatrixInput
+
+            || (kvp.Value is NvxMatrixInput input && input.IsEnabled))
+
+        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
     public Dictionary<string, IRoutingOutputSlot> OutputSlots => _outputSlots.Where(
         kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
             .ToDictionary(
@@ -219,7 +221,7 @@ public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(kvp
         }
 
         if (
-            (type.Has(eRoutingSignalType.SecondaryAudio) || type.Has(eRoutingSignalType.Audio))
+            (type.Has(eRoutingSignalType.AudioVideo) || type.Has(eRoutingSignalType.Audio))
             && outputDevice is ISecondaryAudioStreamWithHardware audioOutput
         )
         {

--- a/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
+++ b/src/NvxEpi/Features/Routing/NvxGlobalRouter.cs
@@ -13,7 +13,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
+public class NvxGlobalRouter : EssentialsDevice, IRoutingMidpointWithFeedback
 {
     private static readonly NvxGlobalRouter _instance = new();
 
@@ -21,10 +21,12 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
     public const string RouteOff = "$off";
     public const string NoSourceText = "No Source";
 
-    public IRouting PrimaryStreamRouter { get; private set; }
-    public IRouting SecondaryAudioRouter { get; private set; }
+    public IRoutingMidpointWithFeedback PrimaryStreamRouter { get; private set; }
+    public IRoutingMidpointWithFeedback SecondaryAudioRouter { get; private set; }
 
-    public IRouting UsbRouter { get; private set; }
+    public IRoutingMidpointWithFeedback UsbRouter { get; private set; }
+
+    public event RouteChangedEventHandler RouteChanged;
 
     private NvxGlobalRouter()
         : base(InstanceKey)
@@ -32,6 +34,12 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
         PrimaryStreamRouter = new PrimaryStreamRouter(Key + "-PrimaryStream");
         SecondaryAudioRouter = new SecondaryAudioRouter(Key + "-SecondaryAudio");
         UsbRouter = new UsbRouter(Key + "-Usb");
+
+        // Forward each sub-router's RouteChanged through this device's own event -
+        // preserves the real per-router tracking rather than inventing a parallel one.
+        PrimaryStreamRouter.RouteChanged += (sender, route) => RouteChanged?.Invoke(this, route);
+        SecondaryAudioRouter.RouteChanged += (sender, route) => RouteChanged?.Invoke(this, route);
+        UsbRouter.RouteChanged += (sender, route) => RouteChanged?.Invoke(this, route);
 
         InputPorts = new RoutingPortCollection<RoutingInputPort>();
         OutputPorts = new RoutingPortCollection<RoutingOutputPort>();
@@ -44,8 +52,8 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
         AddPostActivationAction(BuildMatrixRouting);
 
-        //InputSlots = new Dictionary<string, IRoutingInputSlot>();
-        //OutputSlots = new Dictionary<string, IRoutingOutputSlot>();
+        //InputSlots = new Dictionary<string, INvxInputSlot>();
+        //OutputSlots = new Dictionary<string, INvxOutputSlot>();
     }
 
     public static NvxGlobalRouter Instance
@@ -106,14 +114,35 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
             UsbRouter.ExecuteSwitch(inputSelector, outputSelector, signalType);
     }
 
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType)
+    {
+        if (signalType.Has(eRoutingSignalType.Video))
+            PrimaryStreamRouter.ClearRoute(outputSelector, signalType);
+
+        if (
+            signalType.Has(eRoutingSignalType.Audio)
+            || signalType.Has(eRoutingSignalType.AudioVideo)
+        )
+            SecondaryAudioRouter.ClearRoute(outputSelector, signalType);
+
+        if (signalType.HasFlag(eRoutingSignalType.Usb))
+            UsbRouter.ClearRoute(outputSelector, signalType);
+    }
+
+    public List<RouteSwitchDescriptor> CurrentRoutes =>
+        PrimaryStreamRouter.CurrentRoutes
+            .Concat(SecondaryAudioRouter.CurrentRoutes)
+            .Concat(UsbRouter.CurrentRoutes)
+            .ToList();
+
     public void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type)
     {
         throw new NotImplementedException("Execute Numeric Switch");
     }
 
-    private Dictionary<string, IRoutingInputSlot> _inputSlots = new();
-    private Dictionary<string, IRoutingOutputSlot> _outputSlots = new();
-    public Dictionary<string, IRoutingInputSlot> InputSlots => _inputSlots.Where(kvp =>
+    private Dictionary<string, INvxInputSlot> _inputSlots = new();
+    private Dictionary<string, INvxOutputSlot> _outputSlots = new();
+    public Dictionary<string, INvxInputSlot> InputSlots => _inputSlots.Where(kvp =>
 
             kvp.Value is NvxMatrixClearInput
 
@@ -123,7 +152,7 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
 
         .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-    public Dictionary<string, IRoutingOutputSlot> OutputSlots => _outputSlots.Where(
+    public Dictionary<string, INvxOutputSlot> OutputSlots => _outputSlots.Where(
         kvp => kvp.Value is NvxMatrixOutput output && output.IsEnabled)
             .ToDictionary(
                 kvp => kvp.Key,
@@ -141,7 +170,7 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
                 {
                     return new NvxMatrixInput(t);
                 })
-                .Cast<IRoutingInputSlot>()
+                .Cast<INvxInputSlot>()
                 .ToDictionary(i => i.Key, i => i);
 
             var mockInputSlots = DeviceManager
@@ -151,7 +180,7 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
                 {
                     return new NvxMockMatrixInput(md);
                 })
-                .Cast<IRoutingInputSlot>()
+                .Cast<INvxInputSlot>()
                 .ToDictionary(i => i.Key, i => i);
 
             this.LogDebug("Mock Device inputs: {count}", mockInputSlots.Count);
@@ -172,7 +201,7 @@ public class NvxGlobalRouter : EssentialsDevice, IRoutingNumeric, IMatrixRouting
                 .AllDevices.OfType<NvxBaseDevice>()
                 .Where(t => !t.IsTransmitter)
                 .Select((t) => new NvxMatrixOutput(t))
-                .Cast<IRoutingOutputSlot>()
+                .Cast<INvxOutputSlot>()
                 .ToDictionary(t => t.Key, t => t);
         }
         catch (Exception ex)

--- a/src/NvxEpi/Features/Routing/NvxMatrixClearInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixClearInput.cs
@@ -4,7 +4,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxMatrixClearInput : IRoutingInputSlot
+public class NvxMatrixClearInput : INvxInputSlot
 {
     public string TxDeviceKey => string.Empty;
 

--- a/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
@@ -8,7 +8,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxMatrixInput : IRoutingInputSlot
+public class NvxMatrixInput : INvxInputSlot
 {
     private readonly NvxBaseDevice _device;
 

--- a/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixInput.cs
@@ -52,7 +52,7 @@ public class NvxMatrixInput : IRoutingInputSlot
 
     public int SlotNumber => _device.DeviceId;
 
-    public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo | eRoutingSignalType.SecondaryAudio;
+    public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo;
 
     public string Name => _device.Name;
 

--- a/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
@@ -9,7 +9,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxMatrixOutput : IRoutingOutputSlot
+public class NvxMatrixOutput : INvxOutputSlot
 {
     private readonly NvxBaseDevice _device;
 
@@ -31,7 +31,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
 
     public string RxDeviceKey => _device.Key;
 
-    private readonly Dictionary<eRoutingSignalType, IRoutingInputSlot> currentRoutes = new()
+    private readonly Dictionary<eRoutingSignalType, INvxInputSlot> currentRoutes = new()
     {
         {eRoutingSignalType.Audio, default },
         {eRoutingSignalType.Video, default },
@@ -68,7 +68,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
         SetInputRoute(eRoutingSignalType.Audio, inputSlot);
     }
 
-    private void SetInputRoute(eRoutingSignalType type, IRoutingInputSlot input)
+    private void SetInputRoute(eRoutingSignalType type, INvxInputSlot input)
     {
         if (currentRoutes.ContainsKey(type))
         {
@@ -84,7 +84,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
         OutputSlotChanged?.Invoke(this, new EventArgs());
     }
 
-    public Dictionary<eRoutingSignalType, IRoutingInputSlot> CurrentRoutes => currentRoutes;
+    public Dictionary<eRoutingSignalType, INvxInputSlot> CurrentRoutes => currentRoutes;
 
     public int SlotNumber => _device.DeviceId;
 

--- a/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMatrixOutput.cs
@@ -35,9 +35,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
     {
         {eRoutingSignalType.Audio, default },
         {eRoutingSignalType.Video, default },
-        {eRoutingSignalType.UsbInput, default },
-        {eRoutingSignalType.UsbOutput, default },
-        {eRoutingSignalType.SecondaryAudio, default },
+        {eRoutingSignalType.Usb, default },
     };
 
     public IStreamWithHardware Device => _device;
@@ -66,7 +64,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
 
         Debug.LogMessage(Serilog.Events.LogEventLevel.Verbose, "Audio: Found input slot {inputSlot} for {inputNumber}", this, inputSlot?.Key ?? "null", args.IntValue);
 
-        SetInputRoute(eRoutingSignalType.SecondaryAudio, inputSlot);
+        SetInputRoute(eRoutingSignalType.AudioVideo, inputSlot);
         SetInputRoute(eRoutingSignalType.Audio, inputSlot);
     }
 
@@ -90,7 +88,7 @@ public class NvxMatrixOutput : IRoutingOutputSlot
 
     public int SlotNumber => _device.DeviceId;
 
-    public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo | eRoutingSignalType.SecondaryAudio;
+    public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo;
 
     public string Name => _device.Name;
 

--- a/src/NvxEpi/Features/Routing/NvxMockMatrixInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMockMatrixInput.cs
@@ -44,7 +44,7 @@ public class NvxMockMatrixInput : IRoutingInputSlot
     public int SlotNumber => device.DeviceId;
 
     public eRoutingSignalType SupportedSignalTypes =>
-        eRoutingSignalType.AudioVideo | eRoutingSignalType.SecondaryAudio;
+        eRoutingSignalType.AudioVideo;
 
     public string Name => device.Name;
 

--- a/src/NvxEpi/Features/Routing/NvxMockMatrixInput.cs
+++ b/src/NvxEpi/Features/Routing/NvxMockMatrixInput.cs
@@ -7,7 +7,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace NvxEpi.Features.Routing;
 
-public class NvxMockMatrixInput : IRoutingInputSlot
+public class NvxMockMatrixInput : INvxInputSlot
 {
     private readonly NvxMockDevice device;
 

--- a/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
+++ b/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
@@ -16,7 +16,7 @@ using PepperDash.Essentials.Core;
 
 namespace NvxEpi.Features.Routing;
 
-public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
+public class PrimaryStreamRouter : EssentialsDevice, IRoutingMidpointWithFeedback
 {
     public PrimaryStreamRouter(string key)
         : base(key)
@@ -65,6 +65,11 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
     public RoutingPortCollection<RoutingOutputPort> OutputPorts { get; private set; }
 
     public List<RouteSwitchDescriptor> CurrentRoutes { get; } = new();
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType)
+    {
+        ExecuteSwitch(null, outputSelector, signalType);
+    }
 
     public void ExecuteSwitch(
         object inputSelector,

--- a/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
+++ b/src/NvxEpi/Features/Routing/PrimaryStreamRouter.cs
@@ -74,10 +74,7 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
     {
         try
         {
-            if (
-                signalType.Is(eRoutingSignalType.UsbInput)
-                || signalType.Is(eRoutingSignalType.UsbOutput)
-            )
+            if (signalType.Is(eRoutingSignalType.Usb))
             {
                 this.LogDebug("Skipping switch with USB signal type {signalType}", signalType);
 
@@ -208,7 +205,7 @@ public class PrimaryStreamRouter : EssentialsDevice, IRoutingWithFeedback
         });
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         _transmitters ??= GetTransmitterDictionary();
 

--- a/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
+++ b/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
@@ -66,7 +66,7 @@ public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
         }
     }
 
-    public override bool CustomActivate()
+    protected override bool CustomActivate()
     {
         _transmitters ??= GetTransmitterDictionary();
 
@@ -196,10 +196,7 @@ public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
                 outputSelector
             );
 
-            if (
-                signalType.Is(eRoutingSignalType.UsbInput)
-                || signalType.Is(eRoutingSignalType.UsbOutput)
-            )
+            if (signalType.Is(eRoutingSignalType.Usb))
             {
                 this.LogInformation(
                     "Skipping switch with USB signal type {signalType}",

--- a/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
+++ b/src/NvxEpi/Features/Routing/SecondaryAudioRouter.cs
@@ -16,7 +16,7 @@ using PepperDash.Essentials.Core;
 
 namespace NvxEpi.Features.Routing;
 
-public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
+public class SecondaryAudioRouter : EssentialsDevice, IRoutingMidpointWithFeedback
 {
     public SecondaryAudioRouter(string key)
         : base(key)
@@ -180,6 +180,11 @@ public class SecondaryAudioRouter : EssentialsDevice, IRoutingWithFeedback
     public RoutingPortCollection<RoutingOutputPort> OutputPorts { get; private set; }
 
     public List<RouteSwitchDescriptor> CurrentRoutes { get; } = new();
+
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType)
+    {
+        ExecuteSwitch(null, outputSelector, signalType);
+    }
 
     public void ExecuteSwitch(
         object inputSelector,

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -30,10 +30,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         eRoutingSignalType signalType
     )
     {
-        if (
-            !signalType.Has(eRoutingSignalType.UsbInput)
-            && !signalType.Has(eRoutingSignalType.UsbOutput)
-        )
+        if (!signalType.Has(eRoutingSignalType.Usb))
         {
             this.LogDebug("Skipping switch with signal type {signalType}", signalType);
             return;
@@ -88,7 +85,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         ExecuteSwitch(
             inputPort?.Selector ?? null,
             outputPort.Selector,
-            eRoutingSignalType.UsbInput
+            eRoutingSignalType.Usb
         );
     }
 
@@ -290,7 +287,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         {
             var outputPort = new RoutingOutputPort(
                 $"{remoteDevice.Key}-UsbRemote",
-                eRoutingSignalType.UsbInput | eRoutingSignalType.UsbOutput,
+                eRoutingSignalType.Usb,
                 eRoutingPortConnectionType.UsbC,
                 remoteDevice,
                 this
@@ -360,7 +357,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
         {
             var inputPort = new RoutingInputPort(
                 $"{localDevice.Key}-UsbLocal",
-                eRoutingSignalType.UsbInput | eRoutingSignalType.UsbOutput,
+                eRoutingSignalType.Usb,
                 eRoutingPortConnectionType.UsbC,
                 localDevice,
                 this
@@ -421,7 +418,7 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
         var clearRoutePort = new RoutingInputPort(
             "None",
-            eRoutingSignalType.UsbInput | eRoutingSignalType.UsbOutput,
+            eRoutingSignalType.Usb,
             eRoutingPortConnectionType.UsbC,
             null,
             this

--- a/src/NvxEpi/Features/Routing/UsbRouter.cs
+++ b/src/NvxEpi/Features/Routing/UsbRouter.cs
@@ -8,7 +8,7 @@ using PepperDash.Essentials.Core;
 
 namespace NvxEpi.Features.Routing;
 
-public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
+public class UsbRouter : EssentialsDevice, IRoutingMidpointWithFeedback
 {
     public UsbRouter(string key)
         : base(key)
@@ -22,7 +22,12 @@ public class UsbRouter : EssentialsDevice, IRoutingWithFeedback
 
     public event RouteChangedEventHandler RouteChanged;
 
-    #region IRouting Members
+    public void ClearRoute(object outputSelector, eRoutingSignalType signalType)
+    {
+        ExecuteSwitch(null, outputSelector, signalType);
+    }
+
+    #region IRoutingMidpointWithFeedback Members
 
     public void ExecuteSwitch(
         object inputSelector,

--- a/src/NvxEpi/Properties/AssemblyInfo.cs
+++ b/src/NvxEpi/Properties/AssemblyInfo.cs
@@ -6,4 +6,3 @@
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyVersion("1.0.0.*")]
 [assembly: AssemblyInformationalVersion("0.0.0-buildType-build#")]
-[assembly: Crestron.SimplSharp.Reflection.AssemblyInformationalVersion("0.0.0-buildType-build#")]

--- a/src/NvxEpi/Services/InputPorts/SecondaryAudioInput.cs
+++ b/src/NvxEpi/Services/InputPorts/SecondaryAudioInput.cs
@@ -11,7 +11,7 @@ public class SecondaryAudioInput
     {
         var port = new RoutingInputPort(
             DeviceInputEnum.SecondaryAudio.Name,
-            eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
+            eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo,
             eRoutingPortConnectionType.Streaming,
             DeviceInputEnum.SecondaryAudio,
             device)

--- a/src/NvxEpi/Services/InputSwitching/SwitcherForAnalogAudioOutput.cs
+++ b/src/NvxEpi/Services/InputSwitching/SwitcherForAnalogAudioOutput.cs
@@ -32,7 +32,7 @@ public class SwitcherForAnalogAudioOutput : IHandleInputSwitch
         if (routingInput == DeviceInputEnum.NoSwitch)
             return;
 
-        if (type.Has(eRoutingSignalType.Audio) || type.Has(eRoutingSignalType.SecondaryAudio))
+        if (type.Has(eRoutingSignalType.Audio) || type.Has(eRoutingSignalType.AudioVideo))
             SwitchAudio(routingInput);
 
         if (type.Has(eRoutingSignalType.Video))

--- a/src/NvxEpi/Services/InputSwitching/SwitcherForSecondaryAudioOutput.cs
+++ b/src/NvxEpi/Services/InputSwitching/SwitcherForSecondaryAudioOutput.cs
@@ -32,7 +32,7 @@ public class SwitcherForSecondaryAudioOutput : IHandleInputSwitch
 
         _device.LogDebug("Switching input on SecondaryAudioOutput: '{0}' : '{1}'", routingInput.Name, type.ToString());
 
-        if (type.Has(eRoutingSignalType.Audio) || type.Has(eRoutingSignalType.SecondaryAudio))
+        if (type.Has(eRoutingSignalType.Audio) || type.Has(eRoutingSignalType.AudioVideo))
             SwitchAudio(routingInput);
 
         if (type.Has(eRoutingSignalType.Video))
@@ -62,7 +62,7 @@ public class SwitcherForSecondaryAudioOutput : IHandleInputSwitch
     {
         parent.OutputPorts.Add(new RoutingOutputPort(
             Key,
-            eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio,
+            eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo,
             eRoutingPortConnectionType.LineAudio,
             new SwitcherForSecondaryAudioOutput(parent),
             parent));

--- a/src/NvxEpi/Services/TieLines/TieLineConnector.cs
+++ b/src/NvxEpi/Services/TieLines/TieLineConnector.cs
@@ -70,7 +70,7 @@ public class TieLineConnector
                 .SecondaryAudioRouter
                 .InputPorts[SecondaryAudioRouter.GetInputPortKeyForTx(secondaryAudio)] ?? throw new NullReferenceException("SecondaryAudioStreamInput");
 
-            var tieLine = new TieLine(secondaryAudioPort, secondaryAudioInput, eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio);
+            var tieLine = new TieLine(secondaryAudioPort, secondaryAudioInput, eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo);
 
             secondaryAudio.LogVerbose("Adding secondaryAudio tx {tieLine}", tieLine);
 
@@ -90,7 +90,7 @@ public class TieLineConnector
                 .SecondaryAudioRouter
                 .OutputPorts[SecondaryAudioRouter.GetOutputPortKeyForRx(secondaryAudio)] ?? throw new NullReferenceException("SecondaryRouterStreamInput");
 
-            var tieLine = new TieLine(secondaryAudioStreamOutput, secondaryAudioPort, eRoutingSignalType.Audio | eRoutingSignalType.SecondaryAudio);
+            var tieLine = new TieLine(secondaryAudioStreamOutput, secondaryAudioPort, eRoutingSignalType.Audio | eRoutingSignalType.AudioVideo);
 
             secondaryAudio.LogVerbose("Adding secondaryAudio rx {tieLine}", tieLine);
 

--- a/src/NvxEpi/epi-crestron-nvx.4Series.csproj
+++ b/src/NvxEpi/epi-crestron-nvx.4Series.csproj
@@ -3,12 +3,12 @@
     <ProjectType>ProgramLibrary</ProjectType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <Nullable>disable</Nullable>
     <LangVersion>10</LangVersion>
-    <RootNamespace>NvxEpi</RootNamespace>
+    <RootNamespace>PepperDash.Essentials.Plugins</RootNamespace>
     <Deterministic>false</Deterministic>
-    <AssemblyTitle>NvxEpi</AssemblyTitle>
+    <AssemblyTitle>PepperDash.Essentials.Plugins.Crestron.Nvx</AssemblyTitle>
     <Company>PepperDash Technology</Company>
     <Description>This software is a plugin designed to work as a part of PepperDash Essentials for Crestron control processors. This plugin allows for control Crestron NVX devices.</Description>
     <Copyright>Copyright 2026</Copyright>
@@ -17,15 +17,10 @@
     <InformationalVersion>$(Version)</InformationalVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <Authors>PepperDash Technologies</Authors>
+    <AssemblyName>PepperDash.Essentials.Plugins.Crestron.Nvx</AssemblyName>
     <PackageId>PepperDash.Essentials.Plugins.Crestron.Nvx</PackageId>
     <PackageProjectUrl>https://github.com/PepperDash/epi-crestron-nvx</PackageProjectUrl>
     <PackageTags>crestron 4series nvx</PackageTags>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\**" />
@@ -33,7 +28,7 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.28.0">
+    <PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-routing.63">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace NvxEpi.Tests;
+
+public static class AssemblyFixture
+{
+    private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
+    private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
+
+    private static string Configuration
+    {
+        get
+        {
+            var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var parts = baseDir.Split(Path.DirectorySeparatorChar);
+            return parts[^2]; // net8.0 is last, Configuration is second-to-last
+        }
+    }
+
+    // csproj lives at src/NvxEpi/ (not src/ directly), flat <OutputPath>bin\$(Configuration)\</OutputPath>
+    private static string PluginDllPath =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..",
+            "src", "NvxEpi", "bin", Configuration, "net8",
+            "PepperDash.Essentials.Plugins.Crestron.Nvx.dll"));
+
+    private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
+
+    public static MetadataLoadContext Context => LazyContext.Value;
+    public static Assembly PluginAssembly => LazyAssembly.Value;
+
+    private static MetadataLoadContext CreateContext()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+
+        foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
+            dllByName[Path.GetFileName(dll)] = dll;
+
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllByName.TryAdd(Path.GetFileName(dll), dll);
+
+        // project.assets.json (not deps.json - ExcludeAssets=runtime strips deps.json entries)
+        var assetsJsonPath = Path.Combine(SourceDirectory, "obj", "project.assets.json");
+        if (File.Exists(assetsJsonPath))
+        {
+            foreach (var path in ResolveProjectAssetsAssemblies(assetsJsonPath))
+                dllByName.TryAdd(Path.GetFileName(path), path);
+        }
+
+        return new MetadataLoadContext(new PathAssemblyResolver(dllByName.Values));
+    }
+
+    private static IEnumerable<string> ResolveProjectAssetsAssemblies(string assetsJsonPath)
+    {
+        var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(nugetDir))
+            nugetDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages");
+
+        using var stream = File.OpenRead(assetsJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+
+        if (!doc.RootElement.TryGetProperty("targets", out var targets))
+            yield break;
+
+        var target = targets.EnumerateObject().FirstOrDefault();
+        if (target.Value.ValueKind != JsonValueKind.Object)
+            yield break;
+
+        foreach (var lib in target.Value.EnumerateObject())
+        {
+            var slash = lib.Name.LastIndexOf('/');
+            if (slash < 0) continue;
+            var packageId = lib.Name[..slash].ToLowerInvariant();
+            var version = lib.Name[(slash + 1)..];
+
+            if (!lib.Value.TryGetProperty("compile", out var assets) &&
+                !lib.Value.TryGetProperty("runtime", out assets))
+                continue;
+
+            foreach (var asset in assets.EnumerateObject())
+            {
+                if (!asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var dllPath = Path.Combine(nugetDir, packageId, version,
+                    asset.Name.Replace('/', Path.DirectorySeparatorChar));
+                if (File.Exists(dllPath))
+                    yield return dllPath;
+            }
+        }
+    }
+
+    private static Assembly LoadPluginAssembly()
+    {
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+        return Context.LoadFromAssemblyPath(PluginDllPath);
+    }
+
+    public static List<Type> FindFactoryTypes(string baseTypePrefix = "EssentialsPluginDeviceFactory")
+    {
+        return PluginAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && InheritsFromFactory(t, baseTypePrefix))
+            .ToList();
+    }
+
+    // Walks the FULL base-type chain - NvxBaseDeviceFactory<T> sits between the concrete
+    // Nvx*DeviceFactory classes and EssentialsPluginDeviceFactory<T>, so a direct-BaseType-only
+    // check would silently miss all of them.
+    private static bool InheritsFromFactory(Type type, string prefix)
+    {
+        for (var b = type.BaseType; b != null; b = b.BaseType)
+            if (b.IsGenericType && b.GetGenericTypeDefinition().Name.StartsWith(prefix))
+                return true;
+        return false;
+    }
+
+    public static string SourceDirectory =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src", "NvxEpi"));
+
+    private static readonly Lazy<string[]> AllSourceContents = new(() =>
+        Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .Select(File.ReadAllText)
+            .ToArray());
+
+    public static string? FindSourceForClass(string className) =>
+        AllSourceContents.Value.FirstOrDefault(content => DeclaresClass(content, className));
+
+    private static bool DeclaresClass(string content, string className)
+    {
+        var needle = "class " + className;
+        for (var i = content.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = content.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            var after = i + needle.Length;
+            var next = after < content.Length ? content[after] : ' ';
+            if (!char.IsLetterOrDigit(next) && next != '_')
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NvxEpi.Tests;
+
+// POCO configs (no [JsonProperty] attributes) - Newtonsoft's default case-insensitive
+// contract is relied on, so these verify class shape rather than attribute contracts.
+public class ConfigDeserializationTests
+{
+    [Theory]
+    [InlineData("NvxDeviceProperties")]
+    [InlineData("NvxDirectorConfig")]
+    [InlineData("NvxMockDeviceProperties")]
+    public void Config_Class_Exists(string className)
+    {
+        AssemblyFixture.PluginAssembly.GetType($"NvxEpi.Features.Config.{className}")
+            .Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("NvxDeviceProperties")]
+    [InlineData("NvxDirectorConfig")]
+    [InlineData("NvxMockDeviceProperties")]
+    public void Config_Has_Parameterless_Constructor(string className)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType($"NvxEpi.Features.Config.{className}");
+        type!.GetConstructor(Type.EmptyTypes).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("NvxDeviceProperties", "DeviceId")]
+    [InlineData("NvxDeviceProperties", "Control")]
+    [InlineData("NvxDeviceProperties", "Mode")]
+    [InlineData("NvxDeviceProperties", "MulticastVideoAddress")]
+    [InlineData("NvxDeviceProperties", "MulticastAudioAddress")]
+    [InlineData("NvxDeviceProperties", "EnableAutoRoute")]
+    [InlineData("NvxDirectorConfig", "Control")]
+    [InlineData("NvxDirectorConfig", "NumberOfDomains")]
+    public void Config_Has_Expected_Property(string className, string propertyName)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType($"NvxEpi.Features.Config.{className}");
+        type!.GetProperty(propertyName).Should().NotBeNull();
+    }
+}

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NvxEpi.Tests;
+
+public class FactoryDiscoveryTests
+{
+    [Fact]
+    public void Assembly_Loads_Successfully()
+    {
+        AssemblyFixture.PluginAssembly.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Assembly_Name_Matches_Expected()
+    {
+        AssemblyFixture.PluginAssembly.GetName().Name
+            .Should().Be("PepperDash.Essentials.Plugins.Crestron.Nvx");
+    }
+
+    [Fact]
+    public void Factory_Count_Matches_Expected()
+    {
+        AssemblyFixture.FindFactoryTypes().Should().HaveCount(9);
+    }
+
+    [Theory]
+    [InlineData("Nvx35XDeviceFactory")]
+    [InlineData("Nvx36XDeviceFactory")]
+    [InlineData("Nvx38XDeviceFactory")]
+    [InlineData("NvxD3XDeviceFactory")]
+    [InlineData("NvxE20DeviceFactory")]
+    [InlineData("NvxE3XDeviceFactory")]
+    [InlineData("NvxMockDeviceFactory")]
+    [InlineData("NvxDirectorFactory")]
+    [InlineData("NvxApplicationFactory")]
+    public void Factory_Exists_ByName(string factoryClassName)
+    {
+        var factories = AssemblyFixture.FindFactoryTypes();
+        factories.Should().Contain(t => t.Name == factoryClassName);
+    }
+
+    [Fact]
+    public void All_Factories_Have_Parameterless_Constructor()
+    {
+        foreach (var factory in AssemblyFixture.FindFactoryTypes())
+        {
+            factory.GetConstructor(Type.EmptyTypes)
+                .Should().NotBeNull($"factory {factory.Name} must have a parameterless constructor for plugin discovery");
+        }
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NvxEpi.Tests;
+
+// MinimumEssentialsFrameworkVersion and TypeNames are assigned at runtime in the factory
+// constructor, which MetadataLoadContext cannot execute - source scanning is the only way
+// to verify these without spinning up the Essentials runtime.
+public class FactoryMetadataTests
+{
+    private const string ExpectedMinimumEssentialsFrameworkVersion = "3.0.0-dev-v3-routing.63";
+
+    [Theory]
+    [InlineData("Nvx35XDeviceFactory")]
+    [InlineData("Nvx36XDeviceFactory")]
+    [InlineData("Nvx38XDeviceFactory")]
+    [InlineData("NvxD3XDeviceFactory")]
+    [InlineData("NvxE20DeviceFactory")]
+    [InlineData("NvxE3XDeviceFactory")]
+    [InlineData("NvxMockDeviceFactory")]
+    public void Factory_Source_Sets_MinimumEssentialsFrameworkVersion_Via_Shared_Const(string factoryClassName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryClassName);
+        source.Should().NotBeNull();
+        source!.Should().Contain("MinimumEssentialsFrameworkVersion = MinumumEssentialsVersion");
+    }
+
+    [Fact]
+    public void NvxDirectorFactory_Sets_MinimumEssentialsFrameworkVersion_Via_Shared_Const()
+    {
+        var source = AssemblyFixture.FindSourceForClass("NvxDirectorFactory");
+        source.Should().NotBeNull();
+        source!.Should().Contain("MinimumEssentialsFrameworkVersion = NvxBaseDeviceFactory<NvxXioDirector>.MinumumEssentialsVersion");
+    }
+
+    [Fact]
+    public void SharedMinimumEssentialsVersionConst_Matches_Expected()
+    {
+        var source = AssemblyFixture.FindSourceForClass("NvxBaseDeviceFactory");
+        source.Should().NotBeNull();
+        source!.Should().Contain($"MinumumEssentialsVersion = \"{ExpectedMinimumEssentialsFrameworkVersion}\"");
+    }
+
+    [Theory]
+    [InlineData("Nvx35XDeviceFactory", "dmnvx350")]
+    [InlineData("Nvx36XDeviceFactory", "dmnvx360")]
+    [InlineData("Nvx38XDeviceFactory", "dmnvx384")]
+    [InlineData("NvxD3XDeviceFactory", "dmnvxd30")]
+    [InlineData("NvxE20DeviceFactory", "dmnvxe20")]
+    [InlineData("NvxE3XDeviceFactory", "dmnvxe30")]
+    [InlineData("NvxMockDeviceFactory", "MockNvxDevice")]
+    [InlineData("NvxDirectorFactory", "xiodirector")]
+    [InlineData("NvxApplicationFactory", "dynnvx")]
+    public void Factory_Source_Contains_TypeName(string factoryClassName, string typeName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryClassName);
+        source.Should().NotBeNull();
+        source!.Should().Contain($"\"{typeName}\"");
+    }
+}

--- a/tests/epi-crestron-nvx.Tests.csproj
+++ b/tests/epi-crestron-nvx.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensures the plugin is built before tests run (no direct assembly reference) -->
+    <ProjectReference Include="..\src\NvxEpi\epi-crestron-nvx.4Series.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Migrates epi-crestron-nvx (NVX video/audio/USB routing plugin) from v2 (net472, SERIES4, PepperDashEssentials 2.28.0) to v3 (net8, PepperDashEssentials 3.0.0-dev-v3-routing.63). Largest and highest-risk repo in this migration batch (207 source files) - includes both the base v2->v3 mechanics and the full routing-interface overhaul.

## Naming convention fixes
- Renamed `NvxEpi.4Series.{csproj,sln}` -> `epi-crestron-nvx.4Series.{csproj,sln}`
- Fixed `AssemblyName`/`AssemblyTitle`/`RootNamespace` to `PepperDash.Essentials.Plugins(.Crestron.Nvx)` (`PackageId` was already correct)
- C# namespace hierarchy (`NvxEpi.*`, ~40+ sub-namespaces across 201 files) intentionally left as-is - a full flatten to the single-namespace convention was assessed as too high-risk for a codebase this size/organization (see `_Context/v3-migration-plan.md` for the reasoning)

## Base v3 mechanics
- net8 target, both SERIES4 `PropertyGroup`s removed
- `PepperDashEssentials` bumped to `3.0.0-dev-v3-routing.63` (needed the network-switch-poe interfaces plus the routing overhaul)
- Fixed the shared `MinumumEssentialsVersion` const (propagates to all 8 `NvxBaseDeviceFactory<T>` subclasses) + added the missing value to `NvxDirectorFactory`
- Fixed all 24 removed-API hits: `SecondaryAudio`->`AudioVideo`, `UsbInput`/`UsbOutput`->`Usb` (deduped a `Dictionary` that would have thrown on duplicate keys), `GetCType()` removed correctly, `Crestron.SimplSharp.Reflection`->`System.Reflection`, `CType`->`System.Type`, removed a dead duplicate assembly attribute
- `GenericQueue`/`ThreadPriority` fix, `Timer` ambiguity fix (`System.Timers` vs `System.Threading`)
- All 12 `CustomActivate()`/`Initialize()` overrides across the device hierarchy: `public` -> `protected`

## Routing-interface overhaul
- New plugin-local `INvxInputSlot`/`INvxOutputSlot` replacing the removed core `IRoutingInputSlot`/`IRoutingOutputSlot` (confirmed fully plugin-internal via full-repo search before choosing this over a core-interface mapping)
- `NvxGlobalRouter`, `PrimaryStreamRouter`, `SecondaryAudioRouter`, `UsbRouter`: `IRoutingNumeric`/`IMatrixRouting`/`IRoutingWithFeedback` -> `IRoutingMidpointWithFeedback`. Added the missing `ClearRoute` (delegating to each router's existing null-input clear path); `CurrentRoutes`/`RouteChanged` were already present from a prior partial migration attempt on this branch and are reused as-is. `NvxGlobalRouter` forwards each sub-router's `RouteChanged` through its own event and aggregates their `CurrentRoutes`.
- Same treatment for the 6 concrete device classes (`Nvx35X`, `Nvx36X`, `Nvx38X`, `NvxD3X`, `NvxE20`, `NvxE3X`) and `NvxMockDevice` (was `IRoutingNumeric`) - all already had `ExecuteSwitch` matching the new interface; added `ClearRoute` as a no-op (no per-device clear concept exists below the matrix/global-router layer)
- `INvxDevice`: `IRoutingInputsOutputs` -> `IRoutingMidpoint` (pure rename, confirmed via core source)
- `Amplifier`/`NvxApplicationAudioReceiver.Amp`/`NvxApplicationVideoReceiver.Display`: removed `IRoutingSink` (gone) in favor of `IRoutingInputs` - confirmed via full-repo usage search that only `.InputPorts` and the `ReleaseRoute()`/`ReleaseAndMakeRoute()` extension methods were ever used through these properties. Deleted `Amplifier`'s now-genuinely-dead `CurrentSourceInfoKey`/`CurrentSourceInfo`/`CurrentSourceChange`.

## Tests
Added xUnit validation test suite (factory discovery for all 9 factories, factory metadata via the shared const, POCO config shape checks) - 45 tests passing.

## Verification
- `dotnet build`: 0 errors
- IDE diagnostics: clean
- `scan-plugin-v3-readiness`: `isV3=true`, `removedApis=[]`, `threeSeriesArtifacts=[]`

## Notes
- Targets a prerelease Essentials version (3.0.0-dev-v3-routing.63) - marked draft pending that line stabilizing.
- **Routing behavior has NOT been validated on hardware.** Build/discovery/metadata tests passing confirms the assembly loads and discovers correctly - it does not exercise real switching. Mark ready only after bench testing confirms `ClearRoute`/`CurrentRoutes`/`RouteChanged`/actual routing behavior.
- BREAKING CHANGE: requires Essentials v3 and a 4-Series processor.
